### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aoliveti/curling/security/code-scanning/1](https://github.com/aoliveti/curling/security/code-scanning/1)

To fix this problem, add a `permissions` block to the workflow. As recommended, this should either be a global key (applies to all jobs) or specified per-job. Since all jobs here likely only need read access to repository contents, the safest default is:

```yaml
permissions:
  contents: read
```

Add this after the `name: Go` line and before the `on:` key, to apply it to all jobs in the workflow, restricting the `GITHUB_TOKEN` to just read repository contents. If a job or step needs more, you can add additional permissions as needed, but for build, test, and upload coverage, `contents: read` is sufficient.

**Implementation:**  
- Edit `.github/workflows/go.yml`
- Insert the block above after line 4, i.e., after `name: Go`
- No new methods, definitions, or external actions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
