### PR TITLE
Refactor body handling and add test for body restoration

### DIFF
--- a/command_body_test.go
+++ b/command_body_test.go
@@ -81,6 +81,19 @@ func Test_NewFromRequest_body(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "short form body with fallback body size",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(body)),
+				},
+				opts: []Option{WithMaxBodySize(0)},
+			},
+			want:    "curl --data-raw 'key=value' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
 			name: "long form nil body",
 			args: args{
 				r: &http.Request{

--- a/command_body_test.go
+++ b/command_body_test.go
@@ -1,6 +1,7 @@
 package curling
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/url"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_NewFromRequest_body(t *testing.T) {
@@ -220,6 +222,59 @@ func Test_NewFromRequest_body(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+func TestNewFromRequest_BodyRestoration(t *testing.T) {
+	t.Parallel()
+
+	opts := []Option{WithMaxBodySize(10)}
+
+	testUrl := &url.URL{
+		Scheme: "https",
+		Host:   "localhost",
+	}
+
+	tests := []struct {
+		name         string
+		originalBody []byte
+	}{
+		{
+			name:         "body smaller than limit",
+			originalBody: []byte("12345"), // 5 bytes < 10 byte limit
+		},
+		{
+			name:         "body equal to limit",
+			originalBody: []byte("1234567890"), // 10 bytes == 10 byte limit
+		},
+		{
+			name:         "body larger than limit (truncation)",
+			originalBody: []byte("12345678901234"), // 14 bytes > 10 byte limit
+		},
+		{
+			name:         "empty body",
+			originalBody: []byte{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &http.Request{
+				Method: http.MethodPost,
+				URL:    testUrl,
+				Body:   io.NopCloser(bytes.NewReader(tt.originalBody)),
+			}
+
+			_, err := NewFromRequest(r, opts...)
+			require.NoError(t, err, "NewFromRequest should not fail")
+
+			restoredBody, err := io.ReadAll(r.Body)
+			require.NoError(t, err, "Failed to read the restored body")
+
+			assert.Equal(t, tt.originalBody, restoredBody, "Body content was not restored correctly")
 		})
 	}
 }

--- a/option.go
+++ b/option.go
@@ -21,8 +21,7 @@ type config struct {
 	// requestTimeout enables the option -m, --max-time.
 	requestTimeout int
 	// maxBodySize is the maximum number of bytes to read from the request body.
-	// A value of 0 or less means no limit.
-	maxBodySize int64
+	maxBodySize int
 }
 
 // outputStyle groups options related to the command's text formatting.
@@ -130,10 +129,13 @@ func WithRequestTimeout(seconds int) Option {
 
 // WithMaxBodySize limits the request body size (in bytes) to read.
 // This prevents OOM errors on large bodies. If the body is truncated,
-// the output string will be appended with "...[BODY TRUNCATED]".
-// A value of 0 or less means no limit.
-func WithMaxBodySize(bytes int64) Option {
+// the output string will be marked with "... (truncated body)".
+// A value of 0 or less means a default limit (1KB).
+func WithMaxBodySize(bytes int) Option {
 	return func(c *Command) {
+		if bytes <= 0 {
+			bytes = defaultMaxBodySize
+		}
 		c.cfg.maxBodySize = bytes
 	}
 }


### PR DESCRIPTION
- Replaced `io.LimitReader` with `bufio.Reader` to enable non-destructive body peeking and restoration.  
- Enhanced truncation detection logic using `Peek`.  
- Updated `WithMaxBodySize` to handle default sizing for non-positive values.  
- Introduced `TestNewFromRequest_BodyRestoration` to verify body restoration and truncation scenarios.