### PR TITLE
feat: implement smart URL reconstruction for server-side requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 ## Features
 
 * Converts Basic Auth to `-u` and Cookies to `-b`.
+* Rebuilds absolute URLs for server-side requests (middleware), handling missing schemes/hosts and proxy headers.
 * Prioritizes `r.Host` over the `Host:` header, mimicking Go's client.
 * Truncates request bodies by default (1KB) to prevent OOM errors.
 * Supports multi-line output, long-form options, and quote styles.
@@ -78,21 +79,30 @@ You can override this limit using `WithMaxBodySize()`:
 cmd, _ := curling.NewFromRequest(req, curling.WithMaxBodySize(2*1024*1024))
 ```
 
+### Server-Side URL Reconstruction
+
+When used in middleware (server-side), `http.Request` often lacks the `Scheme` and `Host`. The library attempts to reconstruct the full absolute URL by checking (in order):
+
+1. **Proxy Header:** `X-Forwarded-Proto` (only if `WithTrustProxy()` is enabled).
+2. **TLS State:** Checks if the connection is secure.
+3. **Host:** Uses `r.Host` (or `Host` header) and falls back to `r.URL.Host`.
+
 ### Options
 
-| Option | Description |
-| --- | --- |
-| `WithLongForm()` | Use long-form cURL options (e.g., `--request`) |
-| `WithFollowRedirects()` | Set the flag -L, --location |
-| `WithInsecure()` | Set the flag -k, --insecure |
-| `WithSilent()` | Set the flag -s, --silent |
-| `WithCompressed()` | Set the flag --compressed |
-| `WithMultiLine()` | Use multi-line output (Unix) |
-| `WithWindowsMultiLine()` | Use multi-line output (Windows CMD) |
-| `WithPowerShellMultiLine()`| Use multi-line output (PowerShell) |
-| `WithDoubleQuotes()` | Use double quotes for escaping |
-| `WithRequestTimeout(seconds int)` | Set the flag -m, --max-time |
-| `WithMaxBodySize(bytes int64)` | Override the default 1KB body read limit |
+| Option                            | Description                                                          |
+|-----------------------------------|----------------------------------------------------------------------|
+| `WithLongForm()`                  | Use long-form cURL options (e.g., `--request`)                       |
+| `WithFollowRedirects()`           | Set the flag -L, --location                                          |
+| `WithInsecure()`                  | Set the flag -k, --insecure                                          |
+| `WithTrustProxy()`                | Trust `X-Forwarded-Proto` for URL scheme (http/https) reconstruction |
+| `WithSilent()`                    | Set the flag -s, --silent                                            |
+| `WithCompression()`               | Set the flag --compressed                                            |
+| `WithMultiLine()`                 | Use multi-line output (Unix)                                         |
+| `WithWindowsMultiLine()`          | Use multi-line output (Windows CMD)                                  |
+| `WithPowerShellMultiLine()`       | Use multi-line output (PowerShell)                                   |
+| `WithDoubleQuotes()`              | Use double quotes for escaping                                       |
+| `WithRequestTimeout(seconds int)` | Set the flag -m, --max-time                                          |
+| `WithMaxBodySize(bytes int)`      | Override the default 1KB body read limit                             |
 
 ## License
 

--- a/command.go
+++ b/command.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -44,6 +45,8 @@ type requestData struct {
 	// cookies is the formatted string of all cookies (e.g., "k1=v1; k2=v2").
 	cookies string
 
+	uri *url.URL
+
 	// bodyTruncated is true if the body exceeded maxBodySize.
 	bodyTruncated bool
 	// contentLength holds the original Content-Length header, if present.
@@ -77,23 +80,52 @@ func NewFromRequest(r *http.Request, opts ...Option) (*Command, error) {
 // load extracts relevant data from the *http.Request and populates the internal model.
 // It performs a non-destructive read (peek) of the body and restores it,
 // ensuring the request remains valid for subsequent handlers.
-func (m *requestData) load(r *http.Request, cfg config) error {
-	m.request = r
-	m.user, m.pass, m.hasAuth = r.BasicAuth()
+func (d *requestData) load(r *http.Request, cfg config) error {
+	d.request = r
+	d.user, d.pass, d.hasAuth = r.BasicAuth()
 	// Store the original content length
-	m.contentLength = r.ContentLength
+	d.contentLength = r.ContentLength
 
 	// Pre-parse cookies
 	cookies := r.Cookies()
 	if len(cookies) > 0 {
-		m.hasCookies = true
+		d.hasCookies = true
 		var cookieParts []string
 		for _, cookie := range cookies {
 			cookieParts = append(cookieParts, cookie.String())
 		}
-		m.cookies = strings.Join(cookieParts, "; ")
+		d.cookies = strings.Join(cookieParts, "; ")
 	}
 
+	// We create a shallow copy of the URL structure.
+	// This allows us to modify the Scheme/Host in our local copy (d.uri)
+	// without mutating the original URL which might be shared.
+	u := *r.URL
+	d.uri = &u
+
+	// In a server (middleware) context, r.URL.Scheme and r.URL.Host are often missing.
+	if d.uri.Scheme == "" || d.uri.Host == "" {
+		d.uri.Scheme = "http"
+
+		// Check Proxy Headers (if trusted)
+		if cfg.flags.trustProxy {
+			if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+				d.uri.Scheme = proto
+			}
+		}
+
+		// TLS check overrides "http", but usually we respect X-Forwarded-Proto if present
+		if d.uri.Scheme == "http" && r.TLS != nil {
+			d.uri.Scheme = "https"
+		}
+
+		// If URL.Host is empty, fallback to the Request.Host (header value).
+		if d.uri.Host == "" && r.Host != "" {
+			d.uri.Host = r.Host
+		}
+	}
+
+	// If there is no body, we're done.
 	if r.Body == nil || r.Body == http.NoBody {
 		return nil
 	}
@@ -115,16 +147,16 @@ func (m *requestData) load(r *http.Request, cfg config) error {
 		return fmt.Errorf("error reading request body: %w", err)
 	}
 
-	m.body = bytes.NewBuffer(peekBuffer)
-	m.hasData = true
+	d.body = bytes.NewBuffer(peekBuffer)
+	d.hasData = true
 
 	// Check for truncation.
 	// We peeked one byte past the limit (peekSize + 1).
 	// If the error is not EOF, it means the body is longer than peekSize.
 	if !errors.Is(err, io.EOF) {
-		m.bodyTruncated = true
+		d.bodyTruncated = true
 		// Cut the log buffer down to the exact peekSize.
-		m.body.Truncate(peekSize)
+		d.body.Truncate(peekSize)
 	}
 
 	// Restore the full request body for subsequent handlers.
@@ -188,12 +220,12 @@ func buildOptions(args []string, cfg config) []string {
 }
 
 // buildAuth adds the -u/--user flag and handles the Authorization header.
-func buildAuth(args []string, cfg config, model requestData, handledHeaders map[string]bool) []string {
-	if !model.hasAuth {
+func buildAuth(args []string, cfg config, data requestData, handledHeaders map[string]bool) []string {
+	if !data.hasAuth {
 		return args
 	}
 
-	authStr := fmt.Sprintf("%s:%s", model.user, model.pass)
+	authStr := fmt.Sprintf("%s:%s", data.user, data.pass)
 	args = append(args, optionForm(cfg.style, "-u", "--user"), escape(cfg.style, authStr))
 	handledHeaders["Authorization"] = true
 
@@ -201,30 +233,30 @@ func buildAuth(args []string, cfg config, model requestData, handledHeaders map[
 }
 
 // buildCookies adds the -b/--cookie flag and handles the Cookie header.
-func buildCookies(args []string, cfg config, model requestData, handledHeaders map[string]bool) []string {
-	if !model.hasCookies {
+func buildCookies(args []string, cfg config, data requestData, handledHeaders map[string]bool) []string {
+	if !data.hasCookies {
 		return args
 	}
 
-	args = append(args, optionForm(cfg.style, "-b", "--cookie"), escape(cfg.style, model.cookies))
+	args = append(args, optionForm(cfg.style, "-b", "--cookie"), escape(cfg.style, data.cookies))
 	handledHeaders["Cookie"] = true
 
 	return args
 }
 
 // buildData adds the --data-raw flag if data exists.
-func buildData(args []string, cfg config, model requestData) []string {
+func buildData(args []string, cfg config, data requestData) []string {
 	// We only add the flag if a body was present (even if empty).
-	if model.body == nil {
+	if data.body == nil {
 		return args
 	}
 
-	body := model.body.String()
+	body := data.body.String()
 
 	// Add the marker if the body was truncated
-	if model.bodyTruncated {
-		if model.contentLength > 0 {
-			body += fmt.Sprintf("... (truncated body, total %d bytes)", model.contentLength)
+	if data.bodyTruncated {
+		if data.contentLength > 0 {
+			body += fmt.Sprintf("... (truncated body, total %d bytes)", data.contentLength)
 		} else {
 			body += "... (truncated body)"
 		}
@@ -234,18 +266,18 @@ func buildData(args []string, cfg config, model requestData) []string {
 }
 
 // buildMethod adds the -X flag if it is not a cURL default.
-func buildMethod(args []string, cfg config, model requestData) []string {
-	method := model.request.Method
+func buildMethod(args []string, cfg config, data requestData) []string {
+	method := data.request.Method
 	if method == "" {
-		if model.hasData {
+		if data.hasData {
 			method = http.MethodPost
 		} else {
 			method = http.MethodGet
 		}
 	}
 
-	isGetDefault := method == http.MethodGet && !model.hasData
-	isPostDefault := method == http.MethodPost && model.hasData
+	isGetDefault := method == http.MethodGet && !data.hasData
+	isPostDefault := method == http.MethodPost && data.hasData
 
 	if !isGetDefault && !isPostDefault {
 		args = append(args, optionForm(cfg.style, "-X", "--request"), escape(cfg.style, method))
@@ -255,17 +287,19 @@ func buildMethod(args []string, cfg config, model requestData) []string {
 }
 
 // buildURL escapes and adds the URL to the end of the main args.
-func buildURL(args []string, cfg config, model requestData) []string {
-	return append(args, escape(cfg.style, model.request.URL.String()))
+func buildURL(args []string, cfg config, data requestData) []string {
+	return append(args, escape(cfg.style, data.uri.String()))
 }
 
 // buildHeaders builds all non-handled HTTP headers.
-func buildHeaders(cfg config, model requestData, handledHeaders map[string]bool) []string {
-	r := model.request
+func buildHeaders(cfg config, data requestData, handledHeaders map[string]bool) []string {
+	r := data.request
 	if len(r.Header) == 0 && r.Host == "" {
 		return nil
 	}
 
+	// The Host header is usually promoted to the Request.Host field
+	// and removed from the Header map. We start with that value.
 	host := r.Host
 	var headers []string
 	var headerTokens []string
@@ -286,7 +320,9 @@ func buildHeaders(cfg config, model requestData, handledHeaders map[string]bool)
 		headers = append(headers, fmt.Sprintf("%s: %s", canonicalKey, strings.Join(values, ", ")))
 	}
 
-	if host != "" {
+	// Host: We only add it explicitly if it differs from the host in the calculated URL.
+	// This avoids redundant "-H 'Host: ...'" flags when cURL would infer it automatically.
+	if host != "" && data.uri.Host != host {
 		headers = append(headers, fmt.Sprintf("Host: %s", host))
 	}
 

--- a/command_headers_test.go
+++ b/command_headers_test.go
@@ -142,10 +142,10 @@ func Test_NewFromRequest_headers(t *testing.T) {
 				r: &http.Request{
 					Method: http.MethodGet,
 					URL:    testUrl,
-					Host:   "localhost",
+					Host:   "test.example.com",
 				},
 			},
-			want:    "curl 'https://localhost/test' -H 'Host: localhost'",
+			want:    "curl 'https://localhost/test' -H 'Host: test.example.com'",
 			wantErr: assert.NoError,
 		},
 		{

--- a/command_url_test.go
+++ b/command_url_test.go
@@ -1,0 +1,194 @@
+package curling
+
+import (
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewFromRequest_url(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		r    *http.Request
+		opts []Option
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "client side request with full url",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					URL: &url.URL{
+						Scheme: "https",
+						Host:   "api.example.com",
+						Path:   "/v1/users",
+					},
+				},
+			},
+			want:    "curl 'https://api.example.com/v1/users'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "server side request default http",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "localhost:8080",
+					URL: &url.URL{
+						Path: "/health",
+					},
+				},
+			},
+			want:    "curl 'http://localhost:8080/health'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "server side request with tls",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "secure.local",
+					URL: &url.URL{
+						Path: "/login",
+					},
+					TLS: &tls.ConnectionState{},
+				},
+			},
+			want:    "curl 'https://secure.local/login'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "server side request with query params",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "search.com",
+					URL: &url.URL{
+						Path:     "/find",
+						RawQuery: "q=golang&page=1",
+					},
+				},
+			},
+			want:    "curl 'http://search.com/find?q=golang&page=1'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "server side request missing leading slash in path",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "api.io",
+					URL: &url.URL{
+						Path: "v2/data",
+					},
+				},
+			},
+			want:    "curl 'http://api.io/v2/data'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "proxy header ignored without option",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "example.com",
+					URL: &url.URL{
+						Path: "/proxy",
+					},
+					Header: http.Header{
+						"X-Forwarded-Proto": []string{"https"},
+					},
+				},
+			},
+			want:    "curl 'http://example.com/proxy' -H 'X-Forwarded-Proto: https'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "proxy header respected with option",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "example.com",
+					URL: &url.URL{
+						Path: "/proxy",
+					},
+					Header: http.Header{
+						"X-Forwarded-Proto": []string{"https"},
+					},
+				},
+				opts: []Option{WithTrustProxy()},
+			},
+			want:    "curl 'https://example.com/proxy' -H 'X-Forwarded-Proto: https'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "fallback to url host if request host is empty",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					URL: &url.URL{
+						Host: "fallback.com",
+						Path: "/test",
+					},
+				},
+			},
+			want:    "curl 'http://fallback.com/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "ipv6 host",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "[::1]:9090",
+					URL: &url.URL{
+						Path: "/ipv6",
+					},
+				},
+			},
+			want:    "curl 'http://[::1]:9090/ipv6'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "complex url with everything",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					Host:   "complex.org",
+					URL: &url.URL{
+						Path:     "/submit",
+						RawQuery: "id=123",
+					},
+					TLS:  &tls.ConnectionState{},
+					Body: io.NopCloser(strings.NewReader(`{"a":1}`)),
+				},
+			},
+			want:    "curl --data-raw '{\"a\":1}' 'https://complex.org/submit?id=123'",
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewFromRequest(tt.args.r, tt.args.opts...)
+
+			if !tt.wantErr(t, err, "NewFromRequest() error") {
+				return
+			}
+
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}

--- a/option.go
+++ b/option.go
@@ -38,6 +38,8 @@ type curlFlags struct {
 	compressed bool
 	insecure   bool
 	silent     bool
+	// trustProxy enables reading X-Forwarded-* headers to determine the original scheme/host.
+	trustProxy bool
 }
 
 // Option defines a functional option for configuring a [Command].
@@ -137,5 +139,18 @@ func WithMaxBodySize(bytes int) Option {
 			bytes = defaultMaxBodySize
 		}
 		c.cfg.maxBodySize = bytes
+	}
+}
+
+// WithTrustProxy enables the evaluation of "X-Forwarded-Proto" headers.
+//
+// This is useful when the library is used in a middleware behind a Load Balancer
+// or Reverse Proxy that terminates SSL. Without this, the cURL command might
+// generated as "http://" instead of "https://".
+//
+// SECURITY NOTE: Only use this if you trust the upstream proxy.
+func WithTrustProxy() Option {
+	return func(c *Command) {
+		c.cfg.flags.trustProxy = true
 	}
 }


### PR DESCRIPTION
Server-side `http.Request` objects usually lack `Scheme` and `Host` fields, resulting in invalid cURL commands (e.g., `curl '/path'`) when used in middleware.

## Changes
* **URL Reconstruction:** Logic updated to deduce the absolute URL using `r.Host` and TLS connection state if `r.URL.Scheme` or `r.URL.Host` are missing.
* **Proxy Support:** Added `WithTrustProxy` option. When enabled, it respects the `X-Forwarded-Proto` header for correct scheme detection (http/https) behind load balancers.
* **Header Cleanup:** The `Host` header is now omitted from the output if it matches the URL host, reducing redundancy.

## Checklist
- [x] Logic covers both client-side and server-side requests.
- [x] Tests updated for URL reconstruction and proxy scenarios.