### PR TITLE
feat: add data redaction (masked headers) for enhanced security

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 * Rebuilds absolute URLs for server-side requests (middleware), handling missing schemes/hosts and proxy headers.
 * Prioritizes `r.Host` over the `Host:` header, mimicking Go's client.
 * Truncates request bodies by default (1KB) to prevent OOM errors.
+* Supports masking specific headers (e.g., API keys, Authorization tokens) to prevent sensitive data leaks in logs.
 * Supports multi-line output, long-form options, and quote styles.
 
 ## Install
@@ -79,7 +80,7 @@ You can override this limit using `WithMaxBodySize()`:
 cmd, _ := curling.NewFromRequest(req, curling.WithMaxBodySize(2*1024*1024))
 ```
 
-### Server-Side URL Reconstruction
+### Server-side URL reconstruction
 
 When used in middleware (server-side), `http.Request` often lacks the `Scheme` and `Host`. The library attempts to reconstruct the full absolute URL by checking (in order):
 
@@ -89,20 +90,21 @@ When used in middleware (server-side), `http.Request` often lacks the `Scheme` a
 
 ### Options
 
-| Option                            | Description                                                          |
-|-----------------------------------|----------------------------------------------------------------------|
-| `WithLongForm()`                  | Use long-form cURL options (e.g., `--request`)                       |
-| `WithFollowRedirects()`           | Set the flag -L, --location                                          |
-| `WithInsecure()`                  | Set the flag -k, --insecure                                          |
-| `WithTrustProxy()`                | Trust `X-Forwarded-Proto` for URL scheme (http/https) reconstruction |
-| `WithSilent()`                    | Set the flag -s, --silent                                            |
-| `WithCompression()`               | Set the flag --compressed                                            |
-| `WithMultiLine()`                 | Use multi-line output (Unix)                                         |
-| `WithWindowsMultiLine()`          | Use multi-line output (Windows CMD)                                  |
-| `WithPowerShellMultiLine()`       | Use multi-line output (PowerShell)                                   |
-| `WithDoubleQuotes()`              | Use double quotes for escaping                                       |
-| `WithRequestTimeout(seconds int)` | Set the flag -m, --max-time                                          |
-| `WithMaxBodySize(bytes int)`      | Override the default 1KB body read limit                             |
+| Option                                 | Description                                                                                                            |
+|----------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `WithLongForm()`                       | Use long-form cURL options (e.g., `--request`)                                                                         |
+| `WithFollowRedirects()`                | Set the flag -L, --location                                                                                            |
+| `WithInsecure()`                       | Set the flag -k, --insecure                                                                                            |
+| `WithTrustProxy()`                     | Trust `X-Forwarded-Proto` for URL scheme (http/https) reconstruction                                                   |
+| `WithSilent()`                         | Set the flag -s, --silent                                                                                              |
+| `WithCompression()`                    | Set the flag --compressed                                                                                              |
+| `WithMultiLine()`                      | Use multi-line output (Unix)                                                                                           |
+| `WithWindowsMultiLine()`               | Use multi-line output (Windows CMD)                                                                                    |
+| `WithPowerShellMultiLine()`            | Use multi-line output (PowerShell)                                                                                     |
+| `WithDoubleQuotes()`                   | Use double quotes for escaping                                                                                         |
+| `WithRequestTimeout(seconds int)`      | Set the flag -m, --max-time                                                                                            |
+| `WithMaskedHeaders(headers ...string)` | Mask specific headers (values replaced with `*****`).<br/>Handles `-u` password redaction if `Authorization` is masked |
+| `WithMaxBodySize(bytes int)`           | Override the default 1KB body read limit                                                                               |
 
 ## License
 

--- a/command.go
+++ b/command.go
@@ -58,6 +58,7 @@ func NewFromRequest(r *http.Request, opts ...Option) (*Command, error) {
 	var c Command
 
 	// Set default config values
+	c.cfg.maskedHeaders = make(map[string]struct{})
 	c.cfg.maxBodySize = defaultMaxBodySize
 
 	for _, opt := range opts {
@@ -225,8 +226,15 @@ func buildAuth(args []string, cfg config, data requestData, handledHeaders map[s
 		return args
 	}
 
-	authStr := fmt.Sprintf("%s:%s", data.user, data.pass)
-	args = append(args, optionForm(cfg.style, "-u", "--user"), escape(cfg.style, authStr))
+	authValue := fmt.Sprintf("%s:%s", data.user, data.pass)
+
+	// If Authorization is masked, we specifically redact the password part
+	// of the basic auth credential string to prevent leakage in the -u flag.
+	if isMasked(cfg, "Authorization") {
+		authValue = fmt.Sprintf("%s:*****", data.user)
+	}
+
+	args = append(args, optionForm(cfg.style, "-u", "--user"), escape(cfg.style, authValue))
 	handledHeaders["Authorization"] = true
 
 	return args
@@ -317,7 +325,16 @@ func buildHeaders(cfg config, data requestData, handledHeaders map[string]bool) 
 			}
 			continue
 		}
-		headers = append(headers, fmt.Sprintf("%s: %s", canonicalKey, strings.Join(values, ", ")))
+
+		value := strings.Join(values, ", ")
+
+		// Check if the header is configured to be masked.
+		// If so, replace the actual value with a placeholder.
+		if isMasked(cfg, canonicalKey) {
+			value = "*****"
+		}
+
+		headers = append(headers, fmt.Sprintf("%s: %s", canonicalKey, value))
 	}
 
 	// Host: We only add it explicitly if it differs from the host in the calculated URL.
@@ -363,4 +380,10 @@ func escape(style outputStyle, s string) string {
 
 	v := strings.ReplaceAll(s, "'", "'\\''")
 	return fmt.Sprintf("'%s'", v)
+}
+
+// isMasked checks if the given header key is in the maskedHeaders map.
+func isMasked(cfg config, key string) bool {
+	_, ok := cfg.maskedHeaders[http.CanonicalHeaderKey(key)]
+	return ok
 }

--- a/command_headers_test.go
+++ b/command_headers_test.go
@@ -256,6 +256,25 @@ func Test_NewFromRequest_headers(t *testing.T) {
 			want:    "curl --cookie 'c1=v1' 'https://localhost/test'",
 			wantErr: assert.NoError,
 		},
+		{
+			name: "should mask headers",
+			args: args{
+				r: func() *http.Request {
+					r := &http.Request{
+						Method: http.MethodGet,
+						URL:    testUrl,
+						Header: http.Header{},
+					}
+					r.SetBasicAuth("user", "pass")
+					r.Header.Set("X-Api-Key", "api-kei")
+					r.Header.Set("X-User-Agent", "user-agent")
+					return r
+				}(),
+				opts: []Option{WithMaskedHeaders("Authorization", "X-Api-Key")},
+			},
+			want:    "curl -u 'user:*****' 'https://localhost/test' -H 'X-Api-Key: *****' -H 'X-User-Agent: user-agent'",
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/option.go
+++ b/option.go
@@ -1,5 +1,9 @@
 package curling
 
+import (
+	"net/http"
+)
+
 const (
 	// lineContinuationDefault is the default line continuation character (Unix-like).
 	lineContinuationDefault = "\\"
@@ -22,6 +26,8 @@ type config struct {
 	requestTimeout int
 	// maxBodySize is the maximum number of bytes to read from the request body.
 	maxBodySize int
+	// maskedHeaders holds the list of headers to be masked in the output.
+	maskedHeaders map[string]struct{}
 }
 
 // outputStyle groups options related to the command's text formatting.
@@ -152,5 +158,18 @@ func WithMaxBodySize(bytes int) Option {
 func WithTrustProxy() Option {
 	return func(c *Command) {
 		c.cfg.flags.trustProxy = true
+	}
+}
+
+// WithMaskedHeaders configures a list of HTTP headers to be masked in the output.
+// The values of these headers will be replaced with "*****".
+// Special Case: If "Authorization" is included in the list, the password component
+// of the Basic Auth flag (-u) will also be redacted.
+// This option is case-insensitive.
+func WithMaskedHeaders(headers ...string) Option {
+	return func(c *Command) {
+		for _, h := range headers {
+			c.cfg.maskedHeaders[http.CanonicalHeaderKey(h)] = struct{}{}
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a security feature to prevent sensitive data (such as API keys, tokens, or passwords) from leaking into logs when generating cURL commands.

## Changes

### 1. New Option: `WithMaskedHeaders`
Added a variadic option `WithMaskedHeaders(headers ...string)`.
- Accepts a list of header keys (case-insensitive).
- Stores them internally in a `map[string]struct{}` for O(1) access performance.

### 2. Redaction Logic
- **Standard Headers:** In `buildHeaders`, if a header key is found in the mask list, its value is replaced with `*****`.
- **Basic Auth:** In `buildAuth`, if the `Authorization` header is masked, the logic intelligently detects this and masks the password part of the `-u` flag (e.g., `-u 'user:*****'`).