### PR TITLE
fix: generate separate -H flags for multi-value headers

### DIFF
--- a/command.go
+++ b/command.go
@@ -326,15 +326,18 @@ func buildHeaders(cfg config, data requestData, handledHeaders map[string]bool) 
 			continue
 		}
 
-		value := strings.Join(values, ", ")
+		// Iterate over all values for this header key.
+		// This ensures that headers with multiple values are represented as multiple -H flags,
+		// avoiding data corruption if values contain commas.
+		for _, value := range values {
+			// Check if the header is configured to be masked.
+			// If so, replace the actual value with a placeholder.
+			if isMasked(cfg, canonicalKey) {
+				value = "*****"
+			}
 
-		// Check if the header is configured to be masked.
-		// If so, replace the actual value with a placeholder.
-		if isMasked(cfg, canonicalKey) {
-			value = "*****"
+			headers = append(headers, fmt.Sprintf("%s: %s", canonicalKey, value))
 		}
-
-		headers = append(headers, fmt.Sprintf("%s: %s", canonicalKey, value))
 	}
 
 	// Host: We only add it explicitly if it differs from the host in the calculated URL.

--- a/command_headers_test.go
+++ b/command_headers_test.go
@@ -71,7 +71,7 @@ func Test_NewFromRequest_headers(t *testing.T) {
 					Header: multiValueHeader,
 				},
 			},
-			want:    "curl 'https://localhost/test' -H 'X-Key-Multi: value 1, value 2'",
+			want:    "curl 'https://localhost/test' -H 'X-Key-Multi: value 1' -H 'X-Key-Multi: value 2'",
 			wantErr: assert.NoError,
 		},
 		{
@@ -83,7 +83,7 @@ func Test_NewFromRequest_headers(t *testing.T) {
 					Header: additionalHeader,
 				},
 			},
-			want:    "curl 'https://localhost/test' -H 'X-Key-A: bar' -H 'X-Key-Z: foo, alpha, baz'",
+			want:    "curl 'https://localhost/test' -H 'X-Key-A: bar' -H 'X-Key-Z: alpha' -H 'X-Key-Z: baz' -H 'X-Key-Z: foo'",
 			wantErr: assert.NoError,
 		},
 		{
@@ -120,7 +120,7 @@ func Test_NewFromRequest_headers(t *testing.T) {
 				},
 				opts: []Option{WithLongForm()},
 			},
-			want:    "curl 'https://localhost/test' --header 'X-Key-Multi: value 1, value 2'",
+			want:    "curl 'https://localhost/test' --header 'X-Key-Multi: value 1' --header 'X-Key-Multi: value 2'",
 			wantErr: assert.NoError,
 		},
 		{
@@ -133,7 +133,7 @@ func Test_NewFromRequest_headers(t *testing.T) {
 				},
 				opts: []Option{WithLongForm()},
 			},
-			want:    "curl 'https://localhost/test' --header 'X-Key-A: bar' --header 'X-Key-Z: foo, alpha, baz'",
+			want:    "curl 'https://localhost/test' --header 'X-Key-A: bar' --header 'X-Key-Z: alpha' --header 'X-Key-Z: baz' --header 'X-Key-Z: foo'",
 			wantErr: assert.NoError,
 		},
 		{


### PR DESCRIPTION
This PR overhauls how HTTP headers are converted into cURL flags to ensure strict RFC compliance and prevent data corruption.