### PR TITLE
fix: improve shell-specific command escaping (PowerShell & CMD)

### DIFF
--- a/command.go
+++ b/command.go
@@ -372,21 +372,106 @@ func optionForm(style outputStyle, short, long string) string {
 	return short
 }
 
-// escape escapes a string based on config.
+// isMasked checks if the given header key is in the maskedHeaders map.
+func isMasked(cfg config, key string) bool {
+	_, ok := cfg.maskedHeaders[http.CanonicalHeaderKey(key)]
+	return ok
+}
+
+// escape sanitizes the string based on the configured shell type.
 func escape(style outputStyle, s string) string {
+	switch style.shell {
+	case shellPowerShell:
+		return escapePowerShell(style, s)
+	case shellWindowsCMD:
+		return escapeWindowsCMD(s)
+	default:
+		return escapeUnix(style, s)
+	}
+}
+
+// escapeUnix handles escaping for Bash/Zsh/Unix shells.
+func escapeUnix(style outputStyle, s string) string {
 	if style.useDoubleQuotes {
-		v := strings.ReplaceAll(s, "\"", "\\\"")
+		// Bash Double Quotes: escape \ " ` $
+		v := strings.ReplaceAll(s, "\\", "\\\\")
+		v = strings.ReplaceAll(v, "\"", "\\\"")
 		v = strings.ReplaceAll(v, "`", "\\`")
 		v = strings.ReplaceAll(v, "$", "\\$")
 		return fmt.Sprintf("\"%s\"", v)
 	}
 
+	// Bash Single Quotes: strictly literal, escape ' as '\''
 	v := strings.ReplaceAll(s, "'", "'\\''")
 	return fmt.Sprintf("'%s'", v)
 }
 
-// isMasked checks if the given header key is in the maskedHeaders map.
-func isMasked(cfg config, key string) bool {
-	_, ok := cfg.maskedHeaders[http.CanonicalHeaderKey(key)]
-	return ok
+// escapePowerShell handles escaping for PowerShell.
+func escapePowerShell(style outputStyle, s string) string {
+	if style.useDoubleQuotes {
+		// PowerShell Double Quotes: escape ` " $
+		// Note: Backslash is NOT escaped in PS strings usually, but Backtick is.
+		v := strings.ReplaceAll(s, "`", "``")
+		v = strings.ReplaceAll(v, "\"", "`\"")
+		v = strings.ReplaceAll(v, "$", "`$")
+		return fmt.Sprintf("\"%s\"", v)
+	}
+
+	// PowerShell Single Quotes: escape ' as ''
+	v := strings.ReplaceAll(s, "'", "''")
+	return fmt.Sprintf("'%s'", v)
+}
+
+// escapeWindowsCMD handles escaping for Windows Command Prompt (cmd.exe).
+// It follows Microsoft C Runtime parsing rules.
+// Arguments are wrapped in double quotes.
+// Backslashes are literal, unless they precede a double quote.
+// If they precede a double quote, they must be doubled.
+// Double quotes are escaped as \".
+// Trailing backslashes (preceding the closing quote) must be doubled.
+func escapeWindowsCMD(s string) string {
+	if s == "" {
+		return "\"\""
+	}
+
+	var sb strings.Builder
+	// Pre-allocate: original length + 2 quotes + margin for escapes
+	sb.Grow(len(s) + 16)
+	sb.WriteByte('"') // Opening quote
+
+	backslashCount := 0
+	for _, c := range s {
+		switch c {
+		case '\\':
+			backslashCount++
+			continue
+
+		case '"':
+			// Backslashes before a quote must be doubled (N -> 2N)
+			if backslashCount > 0 {
+				sb.WriteString(strings.Repeat("\\", backslashCount*2))
+			}
+			backslashCount = 0
+			// Escape the quote itself
+			sb.WriteString(`\"`)
+			continue
+		}
+
+		// Default case: Normal character
+		// Flush pending backslashes literally (N -> N)
+		if backslashCount > 0 {
+			sb.WriteString(strings.Repeat("\\", backslashCount))
+		}
+		backslashCount = 0
+		sb.WriteRune(c)
+	}
+
+	// Handle trailing backslashes (at the end of the string).
+	// They must be doubled because they technically precede the closing quote.
+	if backslashCount > 0 {
+		sb.WriteString(strings.Repeat("\\", backslashCount*2))
+	}
+
+	sb.WriteByte('"') // Closing quote
+	return sb.String()
 }

--- a/command_options_test.go
+++ b/command_options_test.go
@@ -169,25 +169,148 @@ func Test_NewFromRequest_options(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "windows multiline option",
+			name: "bash double quotes with history expansion char (!)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("Hello!")),
+				},
+				opts: []Option{WithDoubleQuotes()},
+			},
+			want:    "curl --data-raw \"Hello!\" \"https://localhost/test\"",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "windows cmd empty body",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("")),
+				},
+				opts: []Option{WithWindowsMultiLine()},
+			},
+			want:    "curl --data-raw \"\" \"https://localhost/test\"",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "windows cmd path backslashes",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`C:\Windows\System32`)),
+				},
+				opts: []Option{WithWindowsMultiLine()},
+			},
+			want:    "curl --data-raw \"C:\\Windows\\System32\" \"https://localhost/test\"",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "windows cmd trailing backslash",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`Folder\`)),
+				},
+				opts: []Option{WithWindowsMultiLine()},
+			},
+			want:    `curl --data-raw "Folder\\" "https://localhost/test"`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "windows cmd backslash before quote (trigger doubling)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`path=\"`)),
+				},
+				opts: []Option{WithWindowsMultiLine()},
+			},
+			want:    `curl --data-raw "path=\\\"" "https://localhost/test"`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "windows cmd multiple backslashes before quote",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					// Input: Two backslashes before a quote: \\"
+					Body: io.NopCloser(strings.NewReader(`Wait\\"`)),
+				},
+				opts: []Option{WithWindowsMultiLine()},
+			},
+			want:    `curl --data-raw "Wait\\\\\"" "https://localhost/test"`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "windows multiline option (enforce double quotes)",
 			args: args{
 				r: &http.Request{
 					URL: testUrl,
 				},
 				opts: []Option{WithWindowsMultiLine()},
 			},
-			want:    "curl 'https://localhost/test'",
+			want:    "curl \"https://localhost/test\"",
 			wantErr: assert.NoError,
 		},
 		{
-			name: "powershell multiline option",
+			name: "windows multiline option",
 			args: args{
 				r: &http.Request{
 					URL: testUrl,
 				},
+				opts: []Option{WithWindowsMultiLine(), WithDoubleQuotes()},
+			},
+			want:    "curl \"https://localhost/test\"",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "powershell single quote escaping (default)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("It's a 'tricky' test")),
+				},
 				opts: []Option{WithPowerShellMultiLine()},
 			},
-			want:    "curl 'https://localhost/test'",
+			// PowerShell uses '' to escape a single quote inside single-quoted strings
+			want:    "curl --data-raw 'It''s a ''tricky'' test' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "powershell double quotes escaping (variables and quotes)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					// Body contains: $cost = "100"
+					Body: io.NopCloser(strings.NewReader(`$cost = "100"`)),
+				},
+				opts: []Option{WithPowerShellMultiLine(), WithDoubleQuotes()},
+			},
+			// PowerShell uses backtick (`) to escape $ and " inside double-quoted strings
+			want:    "curl --data-raw \"`$cost = `\"100`\"\" \"https://localhost/test\"",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "powershell double quotes escaping (backticks)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					// Body contains a literal backtick: cmd `exec`
+					Body: io.NopCloser(strings.NewReader("cmd `exec`")),
+				},
+				opts: []Option{WithPowerShellMultiLine(), WithDoubleQuotes()},
+			},
+			// The backtick itself must be escaped with another backtick (``)
+			want:    "curl --data-raw \"cmd ``exec``\" \"https://localhost/test\"",
 			wantErr: assert.NoError,
 		},
 		{

--- a/command_test.go
+++ b/command_test.go
@@ -66,6 +66,7 @@ func TestCommand_String(t *testing.T) {
 					style: outputStyle{
 						useMultiLine:     true,
 						lineContinuation: lineContinuationDefault,
+						shell:            shellUnix,
 					},
 				},
 			},

--- a/option.go
+++ b/option.go
@@ -5,6 +5,15 @@ import (
 )
 
 const (
+	// shellUnix targets Unix-like shells (Bash, Zsh, Sh).
+	shellUnix shellType = iota
+	// shellPowerShell targets Windows PowerShell.
+	shellPowerShell
+	// shellWindowsCMD targets the classic Windows Command Prompt.
+	shellWindowsCMD
+)
+
+const (
 	// lineContinuationDefault is the default line continuation character (Unix-like).
 	lineContinuationDefault = "\\"
 	// lineContinuationWindows is the line continuation character for Windows CMD.
@@ -15,6 +24,8 @@ const (
 	// defaultMaxBodySize is the default maximum body size (in bytes).
 	defaultMaxBodySize = 1024
 )
+
+type shellType int
 
 // config holds all user-configurable settings.
 type config struct {
@@ -36,6 +47,8 @@ type outputStyle struct {
 	useMultiLine     bool
 	useDoubleQuotes  bool
 	lineContinuation string
+	// shell determines the escaping rules to apply.
+	shell shellType
 }
 
 // curlFlags groups common boolean cURL flags.
@@ -93,6 +106,7 @@ func WithMultiLine() Option {
 	return func(c *Command) {
 		c.cfg.style.useMultiLine = true
 		c.cfg.style.lineContinuation = lineContinuationDefault
+		c.cfg.style.shell = shellUnix
 	}
 }
 
@@ -102,6 +116,7 @@ func WithWindowsMultiLine() Option {
 	return func(c *Command) {
 		c.cfg.style.useMultiLine = true
 		c.cfg.style.lineContinuation = lineContinuationWindows
+		c.cfg.style.shell = shellWindowsCMD
 	}
 }
 
@@ -111,6 +126,7 @@ func WithPowerShellMultiLine() Option {
 	return func(c *Command) {
 		c.cfg.style.useMultiLine = true
 		c.cfg.style.lineContinuation = lineContinuationPowerShell
+		c.cfg.style.shell = shellPowerShell
 	}
 }
 


### PR DESCRIPTION
This PR overhauls the string escaping logic to correctly support different shells, fixing syntax errors when generating commands for Windows environments.