### PR TITLE
feat: add env vars, smart globbing, and harden header handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 
 ## Features
 
-* Converts Basic Auth to `-u` and Cookies to `-b`.
-* Rebuilds absolute URLs for server-side requests (middleware), handling missing schemes/hosts and proxy headers.
-* Prioritizes `r.Host` over the `Host:` header, mimicking Go's client.
-* Truncates request bodies by default (1KB) to prevent OOM errors.
-* Supports masking specific headers (e.g., API keys, Authorization tokens) to prevent sensitive data leaks in logs.
-* Supports multi-line output, long-form options, and quote styles.
+* **Smart URL Handling:** Rebuilds absolute URLs for server-side requests (handling multi-hop proxies) and auto-disables globbing (`-g`) for IPv6 or array parameters.
+* **RFC Compliance:** Handles multi-value headers as separate flags and strictly prioritizes `r.Host` (RFC 7230).
+* **Safety:** Automatically removes `Content-Length` to prevent cURL errors and truncates request bodies (1KB default) to avoid OOM.
+* **Privacy & Security:** Supports masking headers (`*****`) or substituting them with environment variables (`$VAR`).
+* **Deterministic Output:** Sorts headers and cookies alphabetically for consistent testing/logging.
+* **Formatting:** Converts Basic Auth to `-u`, Cookies to `-b`, and supports multi-line output/quoting styles.
 
 ## Install
 
@@ -82,29 +82,40 @@ cmd, _ := curling.NewFromRequest(req, curling.WithMaxBodySize(2*1024*1024))
 
 ### Server-side URL reconstruction
 
-When used in middleware (server-side), `http.Request` often lacks the `Scheme` and `Host`. The library attempts to reconstruct the full absolute URL by checking (in order):
+When used in middleware (server-side), `http.Request` often lacks the `Scheme` and `Host`. The library reconstructs the absolute URL using the following logic:
 
-1. **Proxy Header:** `X-Forwarded-Proto` (only if `WithTrustProxy()` is enabled).
-2. **TLS State:** Checks if the connection is secure.
-3. **Host:** Uses `r.Host` (or `Host` header) and falls back to `r.URL.Host`.
+* **Scheme:** Defaults to `http`.
+    * If `WithTrustProxy()` is enabled, `X-Forwarded-Proto` takes precedence (supports multi-hop).
+    * Otherwise, it detects `https` if the connection state (`r.TLS`) is secure.
+* **Host:** Prioritizes `r.Host` (the `Host` header), falling back to `r.URL.Host`.
 
-### Options
+### Environment variable substitution
 
-| Option                                 | Description                                                                                                            |
-|----------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| `WithLongForm()`                       | Use long-form cURL options (e.g., `--request`)                                                                         |
-| `WithFollowRedirects()`                | Set the flag -L, --location                                                                                            |
-| `WithInsecure()`                       | Set the flag -k, --insecure                                                                                            |
-| `WithTrustProxy()`                     | Trust `X-Forwarded-Proto` for URL scheme (http/https) reconstruction                                                   |
-| `WithSilent()`                         | Set the flag -s, --silent                                                                                              |
-| `WithCompression()`                    | Set the flag --compressed                                                                                              |
-| `WithMultiLine()`                      | Use multi-line output (Unix)                                                                                           |
-| `WithWindowsMultiLine()`               | Use multi-line output (Windows CMD)                                                                                    |
-| `WithPowerShellMultiLine()`            | Use multi-line output (PowerShell)                                                                                     |
-| `WithDoubleQuotes()`                   | Use double quotes for escaping                                                                                         |
-| `WithRequestTimeout(seconds int)`      | Set the flag -m, --max-time                                                                                            |
-| `WithMaskedHeaders(headers ...string)` | Mask specific headers (values replaced with `*****`).<br/>Handles `-u` password redaction if `Authorization` is masked |
-| `WithMaxBodySize(bytes int)`           | Override the default 1KB body read limit                                                                               |
+Replace sensitive or dynamic header values with shell environment variables for documentation-friendly output:
+
+```go
+cmd, _ := curling.NewFromRequest(req, curling.WithEnvVar("Authorization", "$API_TOKEN"))
+// Output: curl ... -H 'Authorization: $API_TOKEN'
+```
+
+## Options
+
+| Option                                   | Description                                                                                                            |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `WithLongForm()`                         | Use long-form cURL options (e.g., `--request`)                                                                         |
+| `WithFollowRedirects()`                  | Set the flag -L, --location                                                                                            |
+| `WithInsecure()`                         | Set the flag -k, --insecure                                                                                            |
+| `WithTrustProxy()`                       | Trust `X-Forwarded-Proto` for URL scheme reconstruction                                                                |
+| `WithSilent()`                           | Set the flag -s, --silent                                                                                              |
+| `WithCompression()`                      | Set the flag --compressed                                                                                              |
+| `WithMultiLine()`                        | Use multi-line output (Unix)                                                                                           |
+| `WithWindowsMultiLine()`                 | Use multi-line output (Windows CMD)                                                                                    |
+| `WithPowerShellMultiLine()`              | Use multi-line output (PowerShell)                                                                                     |
+| `WithDoubleQuotes()`                     | Use double quotes for escaping                                                                                         |
+| `WithRequestTimeout(seconds int)`        | Set the flag -m, --max-time                                                                                            |
+| `WithMaskedHeaders(headers ...string)`   | Mask specific headers (`*****`). Handles `-u` password redaction if `Authorization` is masked                          |
+| `WithEnvVar(header, variable string)`    | Replace a header value with an environment variable placeholder (e.g., `$TOKEN`). Priority over masking                |
+| `WithMaxBodySize(bytes int)`             | Override the default 1KB body read limit                                                                               |
 
 ## License
 

--- a/command.go
+++ b/command.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -91,6 +92,12 @@ func (d *requestData) load(r *http.Request, cfg config) error {
 	cookies := r.Cookies()
 	if len(cookies) > 0 {
 		d.hasCookies = true
+
+		// Sort cookies by name for deterministic output.
+		sort.Slice(cookies, func(i, j int) bool {
+			return cookies[i].Name < cookies[j].Name
+		})
+
 		var cookieParts []string
 		for _, cookie := range cookies {
 			cookieParts = append(cookieParts, cookie.String())
@@ -315,13 +322,23 @@ func buildHeaders(cfg config, data requestData, handledHeaders map[string]bool) 
 	for key, values := range r.Header {
 		canonicalKey := http.CanonicalHeaderKey(key)
 
+		// We remove Content-Length because cURL calculates it automatically based on the body data.
+		// Keeping the original header is dangerous if we truncated the body (mismatch)
+		if canonicalKey == "Content-Length" {
+			continue
+		}
+
+		// We skip headers that builders already handled (Auth, Cookies).
 		if handledHeaders[canonicalKey] {
 			continue
 		}
 
+		// Handle Host header extraction separately.
 		if canonicalKey == "Host" {
-			if host == "" {
-				host = strings.Join(values, ", ")
+			if host == "" && len(values) > 0 {
+				// RFC 7230: A client MUST send a Host header field in all HTTP/1.1 request messages.
+				// We take the first value as the authoritative host for comparison.
+				host = values[0]
 			}
 			continue
 		}

--- a/command.go
+++ b/command.go
@@ -59,7 +59,6 @@ func NewFromRequest(r *http.Request, opts ...Option) (*Command, error) {
 	var c Command
 
 	// Set default config values
-	c.cfg.maskedHeaders = make(map[string]struct{})
 	c.cfg.maxBodySize = defaultMaxBodySize
 
 	for _, opt := range opts {
@@ -362,13 +361,8 @@ func buildHeaders(cfg config, data requestData, handledHeaders map[string]bool) 
 		// This ensures that headers with multiple values are represented as multiple -H flags,
 		// avoiding data corruption if values contain commas.
 		for _, value := range values {
-			// Check if the header is configured to be masked.
-			// If so, replace the actual value with a placeholder.
-			if isMasked(cfg, canonicalKey) {
-				value = "*****"
-			}
-
-			headers = append(headers, fmt.Sprintf("%s: %s", canonicalKey, value))
+			sv := sanitizeHeaderValue(cfg, canonicalKey, value)
+			headers = append(headers, fmt.Sprintf("%s: %s", canonicalKey, sv))
 		}
 	}
 
@@ -402,6 +396,22 @@ func optionForm(style outputStyle, short, long string) string {
 		return long
 	}
 	return short
+}
+
+// sanitizeHeaderValue resolves the final string representation of a header value by evaluating configuration rules.
+// It first checks if an environment variable substitution is defined, which takes the highest priority.
+// If no substitution is found, it checks if the header is configured to be masked and returns a redacted placeholder.
+// If neither condition is met, it returns the original header value unchanged.
+func sanitizeHeaderValue(cfg config, key, value string) string {
+	if envVar, ok := cfg.envSubstitutions[key]; ok {
+		return envVar
+	}
+
+	if isMasked(cfg, key) {
+		return "*****"
+	}
+
+	return value
 }
 
 // isMasked checks if the given header key is in the maskedHeaders map.

--- a/command.go
+++ b/command.go
@@ -118,6 +118,11 @@ func (d *requestData) load(r *http.Request, cfg config) error {
 		// Check Proxy Headers (if trusted)
 		if cfg.flags.trustProxy {
 			if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+				// Handle multiple hops (e.g. "https, http").
+				// We only care about the client's original protocol (the first one).
+				if comma := strings.Index(proto, ","); comma != -1 {
+					proto = strings.TrimSpace(proto[:comma])
+				}
 				d.uri.Scheme = proto
 			}
 		}
@@ -184,7 +189,7 @@ func (c *Command) compile() {
 	handledHeaders := make(map[string]bool)
 
 	commandParts := []string{"curl"}
-	commandParts = buildOptions(commandParts, c.cfg)
+	commandParts = buildOptions(commandParts, c.cfg, c.data)
 	commandParts = buildAuth(commandParts, c.cfg, c.data, handledHeaders)
 	commandParts = buildCookies(commandParts, c.cfg, c.data, handledHeaders)
 	commandParts = buildData(commandParts, c.cfg, c.data)
@@ -208,7 +213,7 @@ func (c *Command) String() string {
 }
 
 // buildOptions adds basic curl flags (-s, -k, -L, -m, --compressed)
-func buildOptions(args []string, cfg config) []string {
+func buildOptions(args []string, cfg config, data requestData) []string {
 	if cfg.flags.silent {
 		args = append(args, optionForm(cfg.style, "-s", "--silent"))
 	}
@@ -224,6 +229,16 @@ func buildOptions(args []string, cfg config) []string {
 	if cfg.flags.location {
 		args = append(args, optionForm(cfg.style, "-L", "--location"))
 	}
+
+	// Smart Globbing:
+	// If the URL contains characters that cURL interprets as globbing ranges ([] or {}),
+	// we automatically disable globbing to treat the URL literally.
+	// This prevents syntax errors with IPv6 addresses (e.g., [::1]) or query parameters
+	// containing brackets (e.g., filters[id]=1).
+	if strings.ContainsAny(data.uri.String(), "[]{}") {
+		args = append(args, optionForm(cfg.style, "-g", "--globoff"))
+	}
+
 	return args
 }
 

--- a/command_body_test.go
+++ b/command_body_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -66,6 +67,19 @@ func Test_NewFromRequest_body(t *testing.T) {
 				},
 			},
 			want:    "curl --data-raw '' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "body with Content-Length header",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(body)),
+					Header: http.Header{"Content-Length": {strconv.Itoa(len(body))}},
+				},
+			},
+			want:    "curl --data-raw 'key=value' 'https://localhost/test'",
 			wantErr: assert.NoError,
 		},
 		{

--- a/command_headers_test.go
+++ b/command_headers_test.go
@@ -223,7 +223,7 @@ func Test_NewFromRequest_headers(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "short form multiple cookies",
+			name: "short form multiple ordered cookies",
 			args: args{
 				r: func() *http.Request {
 					r := &http.Request{
@@ -231,12 +231,13 @@ func Test_NewFromRequest_headers(t *testing.T) {
 						URL:    testUrl,
 						Header: http.Header{},
 					}
-					r.AddCookie(&http.Cookie{Name: "c1", Value: "v1"})
-					r.AddCookie(&http.Cookie{Name: "c2", Value: "v2"})
+					r.AddCookie(&http.Cookie{Name: "a", Value: "value"})
+					r.AddCookie(&http.Cookie{Name: "b", Value: "value"})
+					r.AddCookie(&http.Cookie{Name: "c", Value: "value"})
 					return r
 				}(),
 			},
-			want:    "curl -b 'c1=v1; c2=v2' 'https://localhost/test'",
+			want:    "curl -b 'a=value; b=value; c=value' 'https://localhost/test'",
 			wantErr: assert.NoError,
 		},
 		{

--- a/command_headers_test.go
+++ b/command_headers_test.go
@@ -258,7 +258,7 @@ func Test_NewFromRequest_headers(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "should mask headers",
+			name: "should mask headers and basic auth",
 			args: args{
 				r: func() *http.Request {
 					r := &http.Request{
@@ -267,13 +267,50 @@ func Test_NewFromRequest_headers(t *testing.T) {
 						Header: http.Header{},
 					}
 					r.SetBasicAuth("user", "pass")
-					r.Header.Set("X-Api-Key", "api-kei")
-					r.Header.Set("X-User-Agent", "user-agent")
+					r.Header.Set("X-Api-Key", "secret-key")
+					r.Header.Set("X-Public", "public-val")
 					return r
 				}(),
 				opts: []Option{WithMaskedHeaders("Authorization", "X-Api-Key")},
 			},
-			want:    "curl -u 'user:*****' 'https://localhost/test' -H 'X-Api-Key: *****' -H 'X-User-Agent: user-agent'",
+			want:    "curl -u 'user:*****' 'https://localhost/test' -H 'X-Api-Key: *****' -H 'X-Public: public-val'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "env var substitution",
+			args: args{
+				r: func() *http.Request {
+					r := &http.Request{
+						Method: http.MethodGet,
+						URL:    testUrl,
+						Header: http.Header{},
+					}
+					r.Header.Set("Authorization", "Bearer token")
+					return r
+				}(),
+				opts: []Option{WithEnvVar("Authorization", "$AUTH_TOKEN")},
+			},
+			want:    "curl 'https://localhost/test' -H 'Authorization: $AUTH_TOKEN'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "env var priority over masking",
+			args: args{
+				r: func() *http.Request {
+					r := &http.Request{
+						Method: http.MethodGet,
+						URL:    testUrl,
+						Header: http.Header{},
+					}
+					r.Header.Set("X-Secret", "value")
+					return r
+				}(),
+				opts: []Option{
+					WithMaskedHeaders("X-Secret"),
+					WithEnvVar("X-Secret", "$SECRET_VAR"),
+				},
+			},
+			want:    "curl 'https://localhost/test' -H 'X-Secret: $SECRET_VAR'",
 			wantErr: assert.NoError,
 		},
 	}

--- a/command_url_test.go
+++ b/command_url_test.go
@@ -133,6 +133,22 @@ func Test_NewFromRequest_url(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "proxy header with multiple hops (comma separated)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "example.com",
+					URL:    &url.URL{Path: "/"},
+					Header: http.Header{
+						"X-Forwarded-Proto": []string{"https, http"},
+					},
+				},
+				opts: []Option{WithTrustProxy()},
+			},
+			want:    "curl 'https://example.com/' -H 'X-Forwarded-Proto: https, http'",
+			wantErr: assert.NoError,
+		},
+		{
 			name: "fallback to url host if request host is empty",
 			args: args{
 				r: &http.Request{
@@ -147,7 +163,7 @@ func Test_NewFromRequest_url(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "ipv6 host",
+			name: "ipv6 host (globbing disabled by default, short form)",
 			args: args{
 				r: &http.Request{
 					Method: http.MethodGet,
@@ -157,7 +173,22 @@ func Test_NewFromRequest_url(t *testing.T) {
 					},
 				},
 			},
-			want:    "curl 'http://[::1]:9090/ipv6'",
+			want:    "curl -g 'http://[::1]:9090/ipv6'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "ipv6 host (globbing disabled by default, long form)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodGet,
+					Host:   "[::1]:9090",
+					URL: &url.URL{
+						Path: "/ipv6",
+					},
+				},
+				opts: []Option{WithLongForm()},
+			},
+			want:    "curl --globoff 'http://[::1]:9090/ipv6'",
 			wantErr: assert.NoError,
 		},
 		{

--- a/option.go
+++ b/option.go
@@ -39,6 +39,8 @@ type config struct {
 	maxBodySize int
 	// maskedHeaders holds the list of headers to be masked in the output.
 	maskedHeaders map[string]struct{}
+	// envSubstitutions maps header keys to environment variable names.
+	envSubstitutions map[string]string
 }
 
 // outputStyle groups options related to the command's text formatting.
@@ -184,8 +186,25 @@ func WithTrustProxy() Option {
 // This option is case-insensitive.
 func WithMaskedHeaders(headers ...string) Option {
 	return func(c *Command) {
+		if c.cfg.maskedHeaders == nil {
+			c.cfg.maskedHeaders = make(map[string]struct{})
+		}
+
 		for _, h := range headers {
 			c.cfg.maskedHeaders[http.CanonicalHeaderKey(h)] = struct{}{}
 		}
+	}
+}
+
+// WithEnvVar replaces the value of a specific header with an environment variable placeholder
+// in the generated command.
+// Priority: This option takes precedence over WithMaskedHeaders.
+func WithEnvVar(header, variableName string) Option {
+	return func(c *Command) {
+		if c.cfg.envSubstitutions == nil {
+			c.cfg.envSubstitutions = make(map[string]string)
+		}
+
+		c.cfg.envSubstitutions[http.CanonicalHeaderKey(header)] = variableName
 	}
 }


### PR DESCRIPTION
## Summary
Introduces robust features for production use cases and hardens header handling logic.

## Changes

### Features
* **Env Var Substitution:** Added `WithEnvVar` to replace header values with shell variables (e.g., `$TOKEN`) for documentation purposes.
* **Smart Globbing:** Automatically appends `--globoff` (`-g`) if the URL contains brackets `[]` or `{}` (e.g., IPv6, query arrays), preventing cURL syntax errors.

### Fixes & Hardening
* **Multi-hop Proxy:** `WithTrustProxy` now parses comma-separated `X-Forwarded-Proto` headers correctly, using the first scheme.
* **Content-Length:** Always stripped from output. cURL calculates this automatically; manual inclusion causes hangs on size mismatches.
* **Strict Host:** Fixed invalid joining of multiple Host headers; now selects the first value if `r.Host` is empty (RFC 7230).

### Polish
* **Deterministic Output:** Cookies are now sorted alphabetically by name.
* **Documentation:** Updated README with new options and clarified server-side URL reconstruction logic.