### PR TITLE
feat: add JSON body masking with fail-secure logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@
 * **Smart URL Handling:** Rebuilds absolute URLs for server-side requests (handling multi-hop proxies) and auto-disables globbing (`-g`) for IPv6 or array parameters.
 * **RFC Compliance:** Handles multi-value headers as separate flags and strictly prioritizes `r.Host` (RFC 7230).
 * **Safety:** Automatically removes `Content-Length` to prevent cURL errors and truncates request bodies (1KB default) to avoid OOM.
-* **Header Privacy:** Supports masking specific headers (`*****`) or substituting them with environment variables (`$VAR`).
-* **Body Security:** Supports masking the entire request body (`[CONTENT MASKED]`) to prevent PII leakage.
+* **Privacy & Security:** Supports masking headers (`*****`), specific JSON keys, or the entire body (`[CONTENT MASKED]`). Also supports environment variable substitution (`$VAR`).
 * **Deterministic Output:** Sorts headers and cookies alphabetically for consistent testing/logging.
 * **Formatting:** Converts Basic Auth to `-u`, Cookies to `-b`, and supports multi-line output with shell-specific escaping (Bash, PowerShell, CMD).
 
@@ -101,6 +100,16 @@ cmd, _ := curling.NewFromRequest(req, curling.WithEnvVar("Authorization", "$API_
 // Output: curl ... -H 'Authorization: $API_TOKEN'
 ```
 
+### JSON body privacy
+
+Redact specific keys within a JSON request body while preserving the structure. If the body is truncated or invalid JSON, it falls back to masking the entire body for safety.
+
+```go
+// Masks "password" recursively in the JSON body
+cmd, _ := curling.NewFromRequest(req, curling.WithMaskedJSONFields("password"))
+// Output: curl ... --data-raw '{"user":"admin","password":"*****"}'
+```
+
 ### Options
 
 | Option                                 | Description                                                                                                 |
@@ -118,6 +127,7 @@ cmd, _ := curling.NewFromRequest(req, curling.WithEnvVar("Authorization", "$API_
 | `WithRequestTimeout(seconds int)`      | Set the flag -m, --max-time                                                                                 |
 | `WithMaskedHeaders(headers ...string)` | Mask specific **headers** (`*****`). Handles `-u` password redaction if `Authorization` is masked           |
 | `WithMaskedBody()`                     | Replace the **request body** with `[CONTENT MASKED]` for security                                           |
+| `WithMaskedJSONFields(keys ...string)` | Mask specific **JSON keys** in the body (`*****`). Falls back to total masking if JSON is invalid           |
 | `WithEnvVar(header, variable string)`  | Replace a **header value** with an environment variable placeholder (e.g., `$TOKEN`). Priority over masking |
 | `WithMaxBodySize(bytes int)`           | Override the default 1KB body read limit                                                                    |
 

--- a/command.go
+++ b/command.go
@@ -3,6 +3,7 @@ package curling
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -292,6 +293,19 @@ func buildData(args []string, cfg config, data requestData) []string {
 
 	body := data.body.String()
 
+	if len(cfg.maskedJSONFields) > 0 {
+		if data.bodyTruncated {
+			return append(args, "--data-raw", escape(cfg.style, "[CONTENT MASKED: invalid or truncated JSON]"))
+		}
+
+		maskedBody, err := maskJSONContent(body, cfg.maskedJSONFields)
+		if err != nil {
+			return append(args, "--data-raw", escape(cfg.style, "[CONTENT MASKED: invalid or truncated JSON]"))
+		}
+
+		return append(args, "--data-raw", escape(cfg.style, maskedBody))
+	}
+
 	// Add the marker if the body was truncated
 	if data.bodyTruncated {
 		if data.contentLength > 0 {
@@ -428,6 +442,43 @@ func sanitizeHeaderValue(cfg config, key, value string) string {
 func isMasked(cfg config, key string) bool {
 	_, ok := cfg.maskedHeaders[http.CanonicalHeaderKey(key)]
 	return ok
+}
+
+// maskJSONContent parses the body and redacts specific keys recursively.
+// Returns an error if the body is not valid JSON.
+func maskJSONContent(body string, fields map[string]struct{}) (string, error) {
+	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+		return "", fmt.Errorf("not a valid JSON object or array")
+	}
+
+	var v interface{}
+	if err := json.Unmarshal([]byte(trimmed), &v); err != nil {
+		return "", err
+	}
+
+	maskJSONFields(v, fields)
+
+	maskedBody, err := json.Marshal(v)
+	return string(maskedBody), err
+}
+
+// maskJSONFields traverses the interface{} tree to find and mask the JSON fields.
+func maskJSONFields(data interface{}, fields map[string]struct{}) {
+	switch d := data.(type) {
+	case map[string]interface{}:
+		for k, v := range d {
+			if _, ok := fields[k]; ok {
+				d[k] = "*****"
+				continue
+			}
+			maskJSONFields(v, fields)
+		}
+	case []interface{}:
+		for _, v := range d {
+			maskJSONFields(v, fields)
+		}
+	}
 }
 
 // escape sanitizes the string based on the configured shell type.

--- a/command_body_test.go
+++ b/command_body_test.go
@@ -302,6 +302,84 @@ func Test_NewFromRequest_body(t *testing.T) {
 			want:    "curl --data-raw 'abcdefghij... (truncated body)' 'https://localhost/test'",
 			wantErr: assert.NoError,
 		},
+		{
+			name: "json masking success",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`{"user": "admin", "pass": "secret", "meta": {"token": "123"}}`)),
+				},
+				opts: []Option{WithMaskedJSONFields("pass", "token")},
+			},
+			want:    `curl --data-raw '{"meta":{"token":"*****"},"pass":"*****","user":"admin"}' 'https://localhost/test'`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "json masking inside array",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`[{"id": 1, "token": "secret1"}, {"id": 2, "token": "secret2"}]`)),
+				},
+				opts: []Option{WithMaskedJSONFields("token")},
+			},
+			want:    `curl --data-raw '[{"id":1,"token":"*****"},{"id":2,"token":"*****"}]' 'https://localhost/test'`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "json masking top-level object",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`{"id": 101, "billing": {"card": "4444", "address": {"city": "Rome"}}}`)),
+				},
+				opts: []Option{WithMaskedJSONFields("billing")},
+			},
+			want:    `curl --data-raw '{"billing":"*****","id":101}' 'https://localhost/test'`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "json masking fast check failure (non-json body)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("plain text body starting with non-json char")),
+				},
+				opts: []Option{WithMaskedJSONFields("password")},
+			},
+			want:    "curl --data-raw '[CONTENT MASKED: invalid or truncated JSON]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "json masking fail-secure on invalid json",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`{"user": "admin", "pass": "sec`)),
+				},
+				opts: []Option{WithMaskedJSONFields("pass")},
+			},
+			want:    "curl --data-raw '[CONTENT MASKED: invalid or truncated JSON]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "json masking fail-secure on truncation",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`{"user": "admin", "pass": "sec"}`)),
+				},
+				opts: []Option{WithMaskedJSONFields("pass"), WithMaxBodySize(5)},
+			},
+			want:    "curl --data-raw '[CONTENT MASKED: invalid or truncated JSON]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/option.go
+++ b/option.go
@@ -43,6 +43,8 @@ type config struct {
 	envSubstitutions map[string]string
 	// maskBody determines if the request body should be redacted in the output.
 	maskBody bool
+	// maskedJSONFields holds the list of JSON fields to be masked in the output.
+	maskedJSONFields map[string]struct{}
 }
 
 // outputStyle groups options related to the command's text formatting.
@@ -216,5 +218,20 @@ func WithEnvVar(header, variableName string) Option {
 func WithMaskedBody() Option {
 	return func(c *Command) {
 		c.cfg.maskBody = true
+	}
+}
+
+// WithMaskedJSONFields configures a list of JSON keys to be redacted in the request body.
+// It parses the body as JSON and recursively replaces the values of matching keys with "*****", handling nested objects and arrays.
+// If the body is not valid JSON or is truncated, the library falls back to masking the entire body to ensure no secrets are leaked (fail-secure behavior).
+// Note that if WithMaskedBody is also enabled, this option is ignored as total masking takes precedence.
+func WithMaskedJSONFields(fields ...string) Option {
+	return func(c *Command) {
+		if c.cfg.maskedJSONFields == nil {
+			c.cfg.maskedJSONFields = make(map[string]struct{})
+		}
+		for _, f := range fields {
+			c.cfg.maskedJSONFields[f] = struct{}{}
+		}
 	}
 }


### PR DESCRIPTION
- Added `WithMaskedJSONFields` to recursively redact specific keys in JSON bodies (maps and arrays) while preserving structure.
- Implemented "Fail-Secure" fallback. If the body is truncated or invalid JSON, the library automatically switches to full body masking to prevent secrets leakage.