### PR TITLE
ci: optimize and update go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,9 +1,4 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go
-permissions:
-  contents: read
 
 on:
   push:
@@ -11,32 +6,34 @@ on:
   pull_request:
     branches: [ "main" ]
 
-jobs:
+permissions:
+  contents: read
 
-  build:
+jobs:
+  test:
+    name: test-and-lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: '1.22'
-        cache: true
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache: true
 
-    - name: Lint
-      uses: golangci/golangci-lint-action@v8
-      with:
-        version: v2.6.0
+      - name: Lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.6.2
+          args: --timeout=5m
 
-    - name: Build
-      run: go build -v ./...
+      - name: Test
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-    - name: Test
-      run: go test -race -coverprofile=coverage.txt -covermode=atomic
-
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        slug: aoliveti/curling
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: aoliveti/curling
+          fail_ci_if_error: true


### PR DESCRIPTION
## Changes
* Update `setup-go` and `golangci-lint` actions to latest versions.
* Set Go version to `stable`.
* Remove redundant `go build` step (covered by `go test`).