### PR TITLE
feat: decouple shell options and fix multiline command formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="assets/images/logo.png" alt="curling logo" width="256">
+<div><img src="assets/images/logo.png" alt="curling logo" width="256"></div>
 
 # curling
 
@@ -9,128 +9,183 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/aoliveti/curling)](https://goreportcard.com/report/github.com/aoliveti/curling)
 ![GitHub License](https://img.shields.io/github/license/aoliveti/curling)
 
-`curling` is a Go library that converts `*http.Request` objects into cURL command strings for debugging.
+`curling` converts Go `*http.Request` objects into safe, reproducible, and executable `curl` commands.
 
-## Features
+It is designed for debugging, logging, and auditing HTTP requests in middleware or testing environments.
 
-* **Smart URL Handling:** Rebuilds absolute URLs for server-side requests (handling multi-hop proxies) and auto-disables globbing (`-g`) for IPv6 or array parameters.
-* **RFC Compliance:** Handles multi-value headers as separate flags and strictly prioritizes `r.Host` (RFC 7230).
-* **Safety:** Automatically removes `Content-Length` to prevent cURL errors and truncates request bodies (1KB default) to avoid OOM.
-* **Privacy & Security:** Supports masking headers (`*****`), specific JSON keys, or the entire body (`[CONTENT MASKED]`). Also supports environment variable substitution (`$VAR`).
-* **Deterministic Output:** Sorts headers and cookies alphabetically for consistent testing/logging.
-* **Formatting:** Converts Basic Auth to `-u`, Cookies to `-b`, and supports multi-line output with shell-specific escaping (Bash, PowerShell, CMD).
+## Why curling?
 
-## Install
+* **Middleware Ready:** Automatically reconstructs URLs for server-side requests where Scheme and Host are missing, and handles multi-hop proxies (`X-Forwarded-Proto`).
+* **Secure by Default:** Prevents secrets leakage via robust masking options for headers, body, and specific JSON keys.
+* **Deterministic:** Sorts headers and cookies alphabetically, ensuring stable logs and reliable snapshot testing.
+* **Shell Aware:** Generates syntax-correct commands for Bash, PowerShell, and Windows CMD, handling complex escaping (e.g., nested quotes, JSON) correctly.
 
-```sh
+## Table of Contents
+
+* [Quick Start](#quick-start)
+* [Features](#features)
+* [Examples](#examples)
+
+    * [1. Basic POST with Auth & Cookies](#1-basic-post-with-auth--cookies)
+    * [2. Multi-line Output for Logging](#2-multi-line-output-for-logging)
+    * [3. Masking JSON Keys](#3-masking-json-keys)
+    * [4. Env Vars Substitution](#4-env-vars-substitution)
+    * [5. Middleware: Server-side URL Reconstruction](#5-middleware-server-side-url-reconstruction)
+* [Options](#options)
+
+    * [General Configuration](#general-configuration)
+    * [Shell & Formatting](#shell--formatting)
+    * [Privacy & Security](#privacy--security)
+* [License](#license)
+
+---
+
+## Quick Start
+
+```bash
 go get -u github.com/aoliveti/curling
 ```
 
-## Usage
-
-Generate a command from an `*http.Request`. Options can be passed to `NewFromRequest`.
+### Example
 
 ```go
 package main
 
 import (
 	"fmt"
-	"log"
 	"net/http"
-	"strings"
-
 	"github.com/aoliveti/curling"
 )
 
 func main() {
-	body := `{"hello": "world"}`
-	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/test", strings.NewReader(body))
-	if err != nil {
-		log.Fatal(err)
-	}
+	req, _ := http.NewRequest("GET", "https://api.example.com/status", nil)
 	
-	req.SetBasicAuth("user", "pass")
-	req.AddCookie(&http.Cookie{Name: "session", Value: "abc12345"})
-	req.Header.Set("X-Request-ID", "12345")
-
-	cmd, err := curling.NewFromRequest(req)
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	// Generate command with default options
+	cmd, _ := curling.NewFromRequest(req)
 	fmt.Println(cmd)
 }
+
+// Output: curl 'https://api.example.com/status'
 ```
 
-**Output:**
+## Features
 
-```sh
-curl -u 'user:pass' -b 'session=abc12345' --data-raw '{"hello": "world"}' 'https://api.example.com/test' -H 'X-Request-Id: 12345'
-```
+* **Smart URL Handling:** Rebuilds absolute URLs for server-side requests and auto-disables globbing (`-g`) for IPv6 or array parameters.
+* **RFC Compliance:** Handles multi-value headers as separate flags (`-H "A: 1" -H "A: 2"`) and strictly prioritizes `r.Host` (RFC 7230).
+* **Safety:** Automatically removes `Content-Length` to prevent cURL errors and truncates request bodies (1KB default) to avoid OOM.
+* **Privacy & Security:** Supports masking headers (`*****`), specific JSON keys, or the entire body (`[CONTENT MASKED]`). Also supports environment variable substitution (`$VAR`).
+* **Formatting:** Converts Basic Auth to `-u`, Cookies to `-b`, and supports multi-line output with shell-specific escaping.
 
-### Body truncation
+## Examples
 
-By default, request bodies are truncated to 1KB. The output includes a marker:
-`... (truncated body, total 5000 bytes)`
-
-You can override this limit using `WithMaxBodySize()`:
+### 1. Basic POST with Auth & Cookies
 
 ```go
-// Set a 2MB limit
-cmd, _ := curling.NewFromRequest(req, curling.WithMaxBodySize(2*1024*1024))
+req, _ := http.NewRequest("POST", "https://api.example.com/test", strings.NewReader(`{"hello":"world"}`))
+req.SetBasicAuth("user", "pass")
+req.AddCookie(&http.Cookie{Name: "session", Value: "abc"})
+
+cmd, _ := curling.NewFromRequest(req)
+
+// Output:
+// curl -u 'user:pass' -b 'session=abc' --data-raw '{"hello":"world"}' 'https://api.example.com/test'
 ```
 
-### Server-side URL reconstruction
+### 2. Multi-line Output for Logging
 
-When used in middleware (server-side), `http.Request` often lacks the `Scheme` and `Host`. The library reconstructs the absolute URL using the following logic:
-
-* **Scheme:** Defaults to `http`.
-    * If `WithTrustProxy()` is enabled, `X-Forwarded-Proto` takes precedence (supports multi-hop).
-    * Otherwise, it detects `https` if the connection state (`r.TLS`) is secure.
-* **Host:** Prioritizes `r.Host` (the `Host` header), falling back to `r.URL.Host`.
-
-### Environment variable substitution
-
-Replace sensitive or dynamic **header values** with shell environment variables (e.g., `$TOKEN`).
-This keeps debug logs clean and safe to share (no secrets leaked), while allowing the command to remain executable in terminals where the variable is set.
+Generate readable commands for log files using `WithMultiLine()`.
 
 ```go
-// Use $API_TOKEN instead of the actual value in the output
-cmd, _ := curling.NewFromRequest(req, curling.WithEnvVar("Authorization", "$API_TOKEN"))
-// Output: curl ... -H 'Authorization: $API_TOKEN'
+// Default (Bash style)
+cmd, _ := curling.NewFromRequest(req, curling.WithMultiLine())
+
+// PowerShell style
+cmd, _ := curling.NewFromRequest(req, curling.WithMultiLine(), curling.WithTargetShell(curling.PowerShell))
 ```
 
-### JSON body privacy
+### 3. Masking JSON Keys
 
-Redact specific keys within a JSON request body while preserving the structure. If the body is truncated or invalid JSON, it falls back to masking the entire body for safety.
+Granularly redact sensitive fields inside a JSON body while keeping the structure for debugging.
 
 ```go
 // Masks "password" recursively in the JSON body
 cmd, _ := curling.NewFromRequest(req, curling.WithMaskedJSONFields("password"))
-// Output: curl ... --data-raw '{"user":"admin","password":"*****"}'
+
+// Output:
+// curl ... --data-raw '{"user":"admin","password":"*****"}'
 ```
 
-### Options
+### 4. Env Vars Substitution
 
-| Option                                 | Description                                                                                                 |
-|----------------------------------------|-------------------------------------------------------------------------------------------------------------|
-| `WithLongForm()`                       | Use long-form cURL options (e.g., `--request`)                                                              |
-| `WithFollowRedirects()`                | Set the flag -L, --location                                                                                 |
-| `WithInsecure()`                       | Set the flag -k, --insecure                                                                                 |
-| `WithTrustProxy()`                     | Trust `X-Forwarded-Proto` for URL scheme reconstruction                                                     |
-| `WithSilent()`                         | Set the flag -s, --silent                                                                                   |
-| `WithCompression()`                    | Set the flag --compressed                                                                                   |
-| `WithMultiLine()`                      | Use multi-line output (Unix/Bash)                                                                           |
-| `WithWindowsMultiLine()`               | Use multi-line output (Windows CMD)                                                                         |
-| `WithPowerShellMultiLine()`            | Use multi-line output (PowerShell)                                                                          |
-| `WithDoubleQuotes()`                   | Use double quotes for escaping (Bash only)                                                                  |
-| `WithRequestTimeout(seconds int)`      | Set the flag -m, --max-time                                                                                 |
-| `WithMaskedHeaders(headers ...string)` | Mask specific **headers** (`*****`). Handles `-u` password redaction if `Authorization` is masked           |
-| `WithMaskedBody()`                     | Replace the **request body** with `[CONTENT MASKED]` for security                                           |
-| `WithMaskedJSONFields(keys ...string)` | Mask specific **JSON keys** in the body (`*****`). Falls back to total masking if JSON is invalid           |
-| `WithEnvVar(header, variable string)`  | Replace a **header value** with an environment variable placeholder (e.g., `$TOKEN`). Priority over masking |
-| `WithMaxBodySize(bytes int)`           | Override the default 1KB body read limit                                                                    |
+Generate shareable commands using shell variables instead of hardcoded secrets.
+
+```go
+// Use $API_TOKEN instead of the actual value
+cmd, _ := curling.NewFromRequest(req, curling.WithEnvVar("Authorization", "$API_TOKEN"))
+
+// Output:
+// curl ... -H 'Authorization: $API_TOKEN'
+```
+
+### 5. Middleware: Server-side URL Reconstruction
+
+When used in middleware, `http.Request` often lacks Scheme and Host. `curling` reconstructs the URL using the following logic:
+
+* **Scheme**: Defaults to `http`.
+
+    * If `WithTrustProxy()` is enabled, `X-Forwarded-Proto` takes precedence.
+    * Otherwise, detects `https` via `r.TLS`.
+* **Host**: Prioritizes `r.Host`, falling back to `r.URL.Host`.
+
+## Options
+
+### General Configuration
+
+| Option                            | Description                                                    |
+|-----------------------------------|----------------------------------------------------------------|
+| `WithLongForm()`                  | Use long-form cURL options (e.g., `--request` instead of `-X`) |
+| `WithSilent()`                    | Set the flag `-s`, `--silent`                                  |
+| `WithCompression()`               | Set the flag `--compressed`                                    |
+| `WithFollowRedirects()`           | Set the flag `-L`, `--location`                                |
+| `WithInsecure()`                  | Set the flag `-k`, `--insecure`                                |
+| `WithRequestTimeout(seconds int)` | Set the flag `-m`, `--max-time`                                |
+| `WithMaxBodySize(bytes int)`      | Override the default 1KB body read limit                       |
+| `WithTrustProxy()`                | Trust `X-Forwarded-Proto` for URL scheme reconstruction        |
+
+### Shell & Formatting
+
+| Option                      | Description                                      |
+|-----------------------------|--------------------------------------------------|
+| `WithMultiLine()`           | Use multi-line output (Unix/Bash style `\`)      |
+| `WithWindowsMultiLine()`    | Use multi-line output (Windows CMD style `^`)    |
+| `WithPowerShellMultiLine()` | Use multi-line output (PowerShell style `` ` ``) |
+| `WithDoubleQuotes()`        | Use double quotes for escaping (Bash only)       |
+
+### Shell & Formatting
+
+| Option                   | Description                                                                                                    |
+|--------------------------|----------------------------------------------------------------------------------------------------------------|
+| `WithMultiLine()`        | Use multi-line output. Uses default `\` separator unless a target shell is set.                                |
+| `WithTargetShell(shell)` | Set target shell syntax (`POSIX`, `PowerShell`, `WindowsCMD`). Configures escaping and line continuation char. |
+| `WithDoubleQuotes()`     | Use double quotes for escaping (Bash only). Ignored for Windows/PowerShell.                                    |
+
+#### Shell Compatibility Matrix
+
+| Shell           | Escaping Strategy                   | Notes                                              |
+|-----------------|-------------------------------------|----------------------------------------------------|
+| **Bash / Zsh**  | Single (`'`) or Double (`"`) quotes | Default. Configurable via `WithDoubleQuotes()`.    |
+| **PowerShell**  | Backticks (`` ` ``)                 | Enforces double quotes for safety.                 |
+| **Windows CMD** | MS C Runtime rules                  | Enforces double quotes; robust backslash handling. |
+
+### Privacy & Security
+
+| Option                          | Description                                                                                                 | Precedence                       |
+|---------------------------------|-------------------------------------------------------------------------------------------------------------|----------------------------------|
+| `WithEnvVar(header, var)`       | Replace a header value with a shell variable (e.g., `$TOKEN`).                                              | Highest (Overrides Masking)      |
+| `WithMaskedHeaders(keys...)`    | Mask specific headers (`*****`). Handles `-u` password redaction if Authorization is masked.                | Normal                           |
+| `WithMaskedBody()`              | Replace the request body with `[CONTENT MASKED]`. Zero-copy optimization.                                   | Highest (Overrides JSON Masking) |
+| `WithMaskedJSONFields(keys...)` | Mask specific JSON keys in the body (`*****`). Falls back to total masking if JSON is invalid or truncated. | Normal                           |
 
 ## License
 
-The library is released under the MIT license. See [LICENSE](https://www.google.com/search?q=LICENSE) file.
+The library is released under the MIT license. See [LICENSE](LICENSE) file.

--- a/command.go
+++ b/command.go
@@ -61,6 +61,8 @@ func NewFromRequest(r *http.Request, opts ...Option) (*Command, error) {
 
 	// Set default config values
 	c.cfg.maxBodySize = defaultMaxBodySize
+	c.cfg.style.lineContinuation = lineContinuationDefault
+	c.cfg.style.shell = POSIX
 
 	for _, opt := range opts {
 		opt(&c)
@@ -204,18 +206,38 @@ func (c *Command) compile() {
 
 	headerParts := buildHeaders(c.cfg, c.data, handledHeaders)
 
-	c.tokens = assembleTokens(commandParts, headerParts)
+	tokens := make([]string, 0, len(commandParts)+len(headerParts))
+	tokens = append(tokens, commandParts...)
+	tokens = append(tokens, headerParts...)
+	c.tokens = tokens
 }
 
 // String returns the cURL command.
 func (c *Command) String() string {
-	separator := " "
-	if c.cfg.style.useMultiLine {
-		separator = fmt.Sprintf(" %s\n", c.cfg.style.lineContinuation)
+	if len(c.tokens) == 0 {
+		return ""
 	}
 
-	s := strings.Join(c.tokens, separator)
-	return strings.TrimSpace(s)
+	// Single-line mode (default): just join tokens with spaces.
+	if !c.cfg.style.useMultiLine {
+		return strings.Join(c.tokens, " ")
+	}
+
+	// Multi-line mode: use continuation character and indentation.
+	var sb strings.Builder
+	// separator: space + continuation char + newline + 2 spaces indentation
+	sep := fmt.Sprintf(" %s\n  ", c.cfg.style.lineContinuation)
+
+	// The first token (curl) acts as the anchor, no indentation prefix.
+	sb.WriteString(c.tokens[0])
+
+	// Subsequent tokens get the indented separator prefix.
+	for _, token := range c.tokens[1:] {
+		sb.WriteString(sep)
+		sb.WriteString(token)
+	}
+
+	return sb.String()
 }
 
 // buildOptions adds basic curl flags (-s, -k, -L, -m, --compressed)
@@ -224,7 +246,8 @@ func buildOptions(args []string, cfg config, data requestData) []string {
 		args = append(args, optionForm(cfg.style, "-s", "--silent"))
 	}
 	if cfg.requestTimeout > 0 {
-		args = append(args, optionForm(cfg.style, "-m", "--max-time"), strconv.Itoa(cfg.requestTimeout))
+		flag := optionForm(cfg.style, "-m", "--max-time")
+		args = append(args, fmt.Sprintf("%s %s", flag, strconv.Itoa(cfg.requestTimeout)))
 	}
 	if cfg.flags.insecure {
 		args = append(args, optionForm(cfg.style, "-k", "--insecure"))
@@ -287,23 +310,27 @@ func buildData(args []string, cfg config, data requestData) []string {
 		return args
 	}
 
+	appendData := func(value string) []string {
+		return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, value)))
+	}
+
 	if cfg.maskBody {
-		return append(args, "--data-raw", escape(cfg.style, "[CONTENT MASKED]"))
+		return appendData("[CONTENT MASKED]")
 	}
 
 	body := data.body.String()
 
 	if len(cfg.maskedJSONFields) > 0 {
 		if data.bodyTruncated {
-			return append(args, "--data-raw", escape(cfg.style, "[CONTENT MASKED: invalid or truncated JSON]"))
+			return appendData("[CONTENT MASKED: invalid or truncated JSON]")
 		}
 
 		maskedBody, err := maskJSONContent(body, cfg.maskedJSONFields)
 		if err != nil {
-			return append(args, "--data-raw", escape(cfg.style, "[CONTENT MASKED: invalid or truncated JSON]"))
+			return appendData("[CONTENT MASKED: invalid or truncated JSON]")
 		}
 
-		return append(args, "--data-raw", escape(cfg.style, maskedBody))
+		return appendData(maskedBody)
 	}
 
 	// Add the marker if the body was truncated
@@ -315,7 +342,7 @@ func buildData(args []string, cfg config, data requestData) []string {
 		}
 	}
 
-	return append(args, "--data-raw", escape(cfg.style, body))
+	return appendData(body)
 }
 
 // buildMethod adds the -X flag if it is not a cURL default.
@@ -333,7 +360,9 @@ func buildMethod(args []string, cfg config, data requestData) []string {
 	isPostDefault := method == http.MethodPost && data.hasData
 
 	if !isGetDefault && !isPostDefault {
-		args = append(args, optionForm(cfg.style, "-X", "--request"), escape(cfg.style, method))
+		flag := optionForm(cfg.style, "-X", "--request")
+		val := escape(cfg.style, method)
+		args = append(args, fmt.Sprintf("%s %s", flag, val))
 	}
 
 	return args
@@ -406,14 +435,6 @@ func buildHeaders(cfg config, data requestData, handledHeaders map[string]bool) 
 	return headerTokens
 }
 
-// assembleTokens constructs the final c.tokens slice.
-func assembleTokens(mainArgs, headerArgs []string) []string {
-	mainCmd := strings.Join(mainArgs, " ")
-	tokens := []string{mainCmd}
-	tokens = append(tokens, headerArgs...)
-	return tokens
-}
-
 // optionForm returns the correct form based on config.
 func optionForm(style outputStyle, short, long string) string {
 	if style.useLongForm {
@@ -484,16 +505,16 @@ func maskJSONFields(data interface{}, fields map[string]struct{}) {
 // escape sanitizes the string based on the configured shell type.
 func escape(style outputStyle, s string) string {
 	switch style.shell {
-	case shellPowerShell:
+	case PowerShell:
 		return escapePowerShell(s)
-	case shellWindowsCMD:
+	case WindowsCMD:
 		return escapeWindowsCMD(s)
 	default:
 		return escapeUnix(style, s)
 	}
 }
 
-// escapeUnix handles escaping for Bash/Zsh/Unix shells.
+// escapeUnix handles escaping for Bash/Zsh/POSIX shells.
 func escapeUnix(style outputStyle, s string) string {
 	if style.useDoubleQuotes {
 		// Bash Double Quotes: escape \ " ` $

--- a/command.go
+++ b/command.go
@@ -206,7 +206,7 @@ func (c *Command) compile() {
 
 	headerParts := buildHeaders(c.cfg, c.data, handledHeaders)
 
-	tokens := make([]string, 0, len(commandParts)+len(headerParts))
+	tokens := make([]string, 0, len(commandParts))
 	tokens = append(tokens, commandParts...)
 	tokens = append(tokens, headerParts...)
 	c.tokens = tokens

--- a/command_options_test.go
+++ b/command_options_test.go
@@ -165,7 +165,7 @@ func Test_NewFromRequest_options(t *testing.T) {
 				},
 				opts: []Option{WithMultiLine()},
 			},
-			want:    "curl 'https://localhost/test'",
+			want:    "curl \\\n  'https://localhost/test'",
 			wantErr: assert.NoError,
 		},
 		{
@@ -178,7 +178,7 @@ func Test_NewFromRequest_options(t *testing.T) {
 				},
 				opts: []Option{WithDoubleQuotes()},
 			},
-			want:    "curl --data-raw \"Hello!\" \"https://localhost/test\"",
+			want:    `curl --data-raw "Hello!" "https://localhost/test"`,
 			wantErr: assert.NoError,
 		},
 		{
@@ -189,9 +189,9 @@ func Test_NewFromRequest_options(t *testing.T) {
 					URL:    testUrl,
 					Body:   io.NopCloser(strings.NewReader("")),
 				},
-				opts: []Option{WithWindowsMultiLine()},
+				opts: []Option{WithTargetShell(WindowsCMD)},
 			},
-			want:    "curl --data-raw \"\" \"https://localhost/test\"",
+			want:    `curl --data-raw "" "https://localhost/test"`,
 			wantErr: assert.NoError,
 		},
 		{
@@ -200,11 +200,11 @@ func Test_NewFromRequest_options(t *testing.T) {
 				r: &http.Request{
 					Method: http.MethodPost,
 					URL:    testUrl,
-					Body:   io.NopCloser(strings.NewReader(`C:\Windows\System32`)),
+					Body:   io.NopCloser(strings.NewReader(`C:\Windows\Path`)),
 				},
-				opts: []Option{WithWindowsMultiLine()},
+				opts: []Option{WithTargetShell(WindowsCMD)},
 			},
-			want:    "curl --data-raw \"C:\\Windows\\System32\" \"https://localhost/test\"",
+			want:    `curl --data-raw "C:\Windows\Path" "https://localhost/test"`,
 			wantErr: assert.NoError,
 		},
 		{
@@ -215,7 +215,7 @@ func Test_NewFromRequest_options(t *testing.T) {
 					URL:    testUrl,
 					Body:   io.NopCloser(strings.NewReader(`Folder\`)),
 				},
-				opts: []Option{WithWindowsMultiLine()},
+				opts: []Option{WithTargetShell(WindowsCMD)},
 			},
 			want:    `curl --data-raw "Folder\\" "https://localhost/test"`,
 			wantErr: assert.NoError,
@@ -228,7 +228,7 @@ func Test_NewFromRequest_options(t *testing.T) {
 					URL:    testUrl,
 					Body:   io.NopCloser(strings.NewReader(`path=\"`)),
 				},
-				opts: []Option{WithWindowsMultiLine()},
+				opts: []Option{WithTargetShell(WindowsCMD)},
 			},
 			want:    `curl --data-raw "path=\\\"" "https://localhost/test"`,
 			wantErr: assert.NoError,
@@ -242,7 +242,7 @@ func Test_NewFromRequest_options(t *testing.T) {
 					// Input: Two backslashes before a quote: \\"
 					Body: io.NopCloser(strings.NewReader(`Wait\\"`)),
 				},
-				opts: []Option{WithWindowsMultiLine()},
+				opts: []Option{WithTargetShell(WindowsCMD)},
 			},
 			want:    `curl --data-raw "Wait\\\\\"" "https://localhost/test"`,
 			wantErr: assert.NoError,
@@ -253,9 +253,9 @@ func Test_NewFromRequest_options(t *testing.T) {
 				r: &http.Request{
 					URL: testUrl,
 				},
-				opts: []Option{WithWindowsMultiLine()},
+				opts: []Option{WithTargetShell(WindowsCMD), WithMultiLine(), WithDoubleQuotes()},
 			},
-			want:    "curl \"https://localhost/test\"",
+			want:    "curl ^\n  \"https://localhost/test\"",
 			wantErr: assert.NoError,
 		},
 		{
@@ -264,7 +264,7 @@ func Test_NewFromRequest_options(t *testing.T) {
 				r: &http.Request{
 					URL: testUrl,
 				},
-				opts: []Option{WithWindowsMultiLine(), WithDoubleQuotes()},
+				opts: []Option{WithTargetShell(WindowsCMD), WithDoubleQuotes()},
 			},
 			want:    "curl \"https://localhost/test\"",
 			wantErr: assert.NoError,
@@ -275,13 +275,26 @@ func Test_NewFromRequest_options(t *testing.T) {
 				r: &http.Request{
 					Method: http.MethodPost,
 					URL:    testUrl,
-					// Body contains: $cost = "100"
-					Body: io.NopCloser(strings.NewReader(`$cost = "100"`)),
+					Body:   io.NopCloser(strings.NewReader(`$cost = "100"`)),
 				},
-				opts: []Option{WithPowerShellMultiLine(), WithDoubleQuotes()},
+				opts: []Option{WithTargetShell(PowerShell)},
 			},
 			// PowerShell uses backtick (`) to escape $ and " inside double-quoted strings
 			want:    "curl --data-raw \"`$cost = `\"100`\"\" \"https://localhost/test\"",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "powershell double quotes escaping with multiline",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`$cost = "100"`)),
+				},
+				opts: []Option{WithTargetShell(PowerShell), WithMultiLine()},
+			},
+			// PowerShell uses backtick (`) to escape $ and " inside double-quoted strings
+			want:    "curl `\n  --data-raw \"`$cost = `\"100`\"\" `\n  \"https://localhost/test\"",
 			wantErr: assert.NoError,
 		},
 		{
@@ -293,7 +306,7 @@ func Test_NewFromRequest_options(t *testing.T) {
 					// Body contains a literal backtick: cmd `exec`
 					Body: io.NopCloser(strings.NewReader("cmd `exec`")),
 				},
-				opts: []Option{WithPowerShellMultiLine(), WithDoubleQuotes()},
+				opts: []Option{WithTargetShell(PowerShell)},
 			},
 			// The backtick itself must be escaped with another backtick (``)
 			want:    "curl --data-raw \"cmd ``exec``\" \"https://localhost/test\"",

--- a/command_options_test.go
+++ b/command_options_test.go
@@ -370,6 +370,7 @@ func Test_NewFromRequest_options(t *testing.T) {
 					Body: io.NopCloser(strings.NewReader("data")),
 				},
 				opts: []Option{
+					WithTargetShell(POSIX),
 					WithFollowRedirects(),
 					WithCompression(),
 					WithInsecure(),

--- a/command_test.go
+++ b/command_test.go
@@ -66,11 +66,11 @@ func TestCommand_String(t *testing.T) {
 					style: outputStyle{
 						useMultiLine:     true,
 						lineContinuation: lineContinuationDefault,
-						shell:            shellUnix,
+						shell:            POSIX,
 					},
 				},
 			},
-			want: "curl -X 'POST' 'https://localhost/test' \\\n-H 'X-Key-1: 1' \\\n-d 'key=value'",
+			want: "curl -X 'POST' 'https://localhost/test' \\\n  -H 'X-Key-1: 1' \\\n  -d 'key=value'",
 		},
 	}
 	for _, tt := range tests {
@@ -82,9 +82,8 @@ func TestCommand_String(t *testing.T) {
 				cfg:    tt.fields.cfg,
 			}
 
-			if got := c.String(); got != tt.want {
-				t.Errorf("String() = %v, want %v", got, tt.want)
-			}
+			got := c.String()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -68,9 +68,9 @@ func Fuzz_NewFromRequest(f *testing.F) {
 		case 1:
 			opts = append(opts, WithMultiLine())
 		case 2:
-			opts = append(opts, WithWindowsMultiLine())
+			opts = append(opts, WithTargetShell(WindowsCMD))
 		case 3:
-			opts = append(opts, WithPowerShellMultiLine())
+			opts = append(opts, WithTargetShell(PowerShell))
 		}
 
 		// Enable Double Quotes if the fifth bit is set.

--- a/option.go
+++ b/option.go
@@ -5,16 +5,16 @@ import (
 )
 
 const (
-	// shellUnix targets Unix-like shells (Bash, Zsh, Sh).
-	shellUnix shellType = iota
-	// shellPowerShell targets Windows PowerShell.
-	shellPowerShell
-	// shellWindowsCMD targets the classic Windows Command Prompt.
-	shellWindowsCMD
+	// POSIX targets Unix-like shells (Bash, Zsh, Sh).
+	POSIX Shell = iota
+	// PowerShell targets Windows PowerShell.
+	PowerShell
+	// WindowsCMD targets the classic Windows Command Prompt.
+	WindowsCMD
 )
 
 const (
-	// lineContinuationDefault is the default line continuation character (Unix-like).
+	// lineContinuationDefault is the default line continuation character (POSIX-like).
 	lineContinuationDefault = "\\"
 	// lineContinuationWindows is the line continuation character for Windows CMD.
 	lineContinuationWindows = "^"
@@ -25,7 +25,7 @@ const (
 	defaultMaxBodySize = 1024
 )
 
-type shellType int
+type Shell int
 
 // config holds all user-configurable settings.
 type config struct {
@@ -54,7 +54,7 @@ type outputStyle struct {
 	useDoubleQuotes  bool
 	lineContinuation string
 	// shell determines the escaping rules to apply.
-	shell shellType
+	shell Shell
 }
 
 // curlFlags groups common boolean cURL flags.
@@ -107,37 +107,34 @@ func WithSilent() Option {
 }
 
 // WithMultiLine splits the command across multiple lines.
-// The default line continuation character is backslash (\).
 func WithMultiLine() Option {
 	return func(c *Command) {
 		c.cfg.style.useMultiLine = true
-		c.cfg.style.lineContinuation = lineContinuationDefault
-		c.cfg.style.shell = shellUnix
 	}
 }
 
-// WithWindowsMultiLine splits the command across multiple lines.
-// The line continuation character is caret (^).
-func WithWindowsMultiLine() Option {
+// WithTargetShell sets the target shell syntax (POSIX, PowerShell, WindowsCMD).
+// It configures the correct escaping rules and line continuation character.
+// Defaults to POSIX.
+func WithTargetShell(shell Shell) Option {
 	return func(c *Command) {
-		c.cfg.style.useMultiLine = true
-		c.cfg.style.lineContinuation = lineContinuationWindows
-		c.cfg.style.shell = shellWindowsCMD
-	}
-}
-
-// WithPowerShellMultiLine splits the command across multiple lines.
-// The line continuation character is backtick (`).
-func WithPowerShellMultiLine() Option {
-	return func(c *Command) {
-		c.cfg.style.useMultiLine = true
-		c.cfg.style.lineContinuation = lineContinuationPowerShell
-		c.cfg.style.shell = shellPowerShell
+		switch shell {
+		case PowerShell:
+			c.cfg.style.lineContinuation = lineContinuationPowerShell
+			c.cfg.style.shell = PowerShell
+		case WindowsCMD:
+			c.cfg.style.lineContinuation = lineContinuationWindows
+			c.cfg.style.shell = WindowsCMD
+		default:
+			c.cfg.style.lineContinuation = lineContinuationDefault
+			c.cfg.style.shell = POSIX
+		}
 	}
 }
 
 // WithDoubleQuotes enables escaping using double quotes (").
 // The default is single quotes (').
+// Only for POSIX shells.
 func WithDoubleQuotes() Option {
 	return func(c *Command) {
 		c.cfg.style.useDoubleQuotes = true


### PR DESCRIPTION
## Summary
This PR refactors how shell syntax is configured, decoupling the "target shell" (escaping rules) from the "output format" (multiline vs single line). It also fixes a logic issue in token assembly that caused poor formatting in multiline output.

## Changes

### 💥 Breaking Changes / API Refactor
* **Removed:** `WithWindowsMultiLine()` and `WithPowerShellMultiLine()`.
* **Added:** `WithTargetShell(shell)` where `shell` can be `curling.Bash`, `curling.PowerShell`, or `curling.CMD`.
* **Updated:** `WithMultiLine()` is now a boolean toggle. It can be combined with any target shell.
    * *Benefit:* Users can now generate single-line commands with PowerShell escaping (e.g., for scripts), which was previously impossible.

### 🐛 Fixes: Token Generation & Indentation
* **Problem:** Previously, the command builder flattened all tokens into a single string or split them incorrectly, breaking the indentation logic in `Command.String()`.
* **Fix:** Refactored `assembleTokens` and builders (e.g., `buildAuth`, `buildOptions`) to keep flags and values paired (e.g., `"-u user:pass"` as one token).
* **Result:** Multiline output now correctly indents arguments on new lines:
    ```bash
    curl \
      -X POST \
      -d 'data' \
      ...
    ```

### 🧪 Testing
* Updated `Fuzz_NewFromRequest` to use the new `WithTargetShell` API, maintaining coverage for all shell types.

### 📝 Documentation
* Updated `README.md` to reflect the new API options and the Shell Compatibility Matrix.