### PR TITLE
feat: Form data parsing, binary content safety, and read optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,32 +15,35 @@ It is designed for debugging, logging, and auditing HTTP requests in middleware 
 
 ## Why curling?
 
-* **Middleware Ready:** Automatically reconstructs URLs for server-side requests where Scheme and Host are missing, and handles multi-hop proxies (`X-Forwarded-Proto`).
-* **Secure by Default:** Prevents secrets leakage via robust masking options for headers, body, and specific JSON keys.
-* **Deterministic:** Sorts headers and cookies alphabetically, ensuring stable logs and reliable snapshot testing.
-* **Shell Aware:** Generates syntax-correct commands for Bash, PowerShell, and Windows CMD, handling complex escaping (e.g., nested quotes, JSON) correctly.
+* **URL reconstruction:** Rebuilds absolute URLs when `Scheme` and `Host` are empty (typical in server-side middleware), optionally supporting `X-Forwarded-Proto`.
+* **Non-destructive reading:** Uses `http.Request.GetBody` when available (client-side) to read the payload without the overhead of buffering and restoring `req.Body`.
+* **Form parsing:** Maps `application/x-www-form-urlencoded` bodies to `-d` flags and `multipart/form-data` to `-F` flags instead of dumping raw strings.
+* **Content sanitization:** Truncates large bodies, omits binary/compressed data, and masks configured headers or JSON fields.
+* **Deterministic output:** Sorts headers, cookies, and form keys alphabetically to ensure consistent output for logs and snapshot testing.
+* **Shell compatibility:** Generates syntax-correct commands for Bash, PowerShell, and Windows CMD, applying shell-specific escaping rules.
 
 ## Table of Contents
 
-* [Quick Start](#quick-start)
+* [Quick start](#quick-start)
 * [Features](#features)
 * [Examples](#examples)
-
-    * [1. Basic POST with Auth & Cookies](#1-basic-post-with-auth--cookies)
-    * [2. Multi-line Output for Logging](#2-multi-line-output-for-logging)
-    * [3. Masking JSON Keys](#3-masking-json-keys)
-    * [4. Env Vars Substitution](#4-env-vars-substitution)
-    * [5. Middleware: Server-side URL Reconstruction](#5-middleware-server-side-url-reconstruction)
+    * [1. Basic POST with auth & cookies](#1-basic-post-with-auth--cookies)
+    * [2. Multi-line output for logging](#2-multi-line-output-for-logging)
+    * [3. Masking JSON keys](#3-masking-json-keys)
+    * [4. Env vars substitution](#4-env-vars-substitution)
+    * [5. Middleware: Server-side URL reconstruction](#5-middleware-server-side-url-reconstruction)
+    * [6. Form data parsing](#6-form-data-parsing)
+    * [7. Multipart uploads](#7-multipart-uploads)
+    * [8. Binary and compressed content](#8-binary-and-compressed-content)
 * [Options](#options)
-
-    * [General Configuration](#general-configuration)
-    * [Shell & Formatting](#shell--formatting)
-    * [Privacy & Security](#privacy--security)
+    * [General configuration](#general-configuration)
+    * [Shell & formatting](#shell--formatting)
+    * [Privacy & security](#privacy--security)
 * [License](#license)
 
 ---
 
-## Quick Start
+## Quick start
 
 ```bash
 go get -u github.com/aoliveti/curling
@@ -54,13 +57,13 @@ package main
 import (
 	"fmt"
 	"net/http"
+
 	"github.com/aoliveti/curling"
 )
 
 func main() {
 	req, _ := http.NewRequest("GET", "https://api.example.com/status", nil)
 	
-	// Generate command with default options
 	cmd, _ := curling.NewFromRequest(req)
 	fmt.Println(cmd)
 }
@@ -70,15 +73,19 @@ func main() {
 
 ## Features
 
-* **Smart URL Handling:** Rebuilds absolute URLs for server-side requests and auto-disables globbing (`-g`) for IPv6 or array parameters.
-* **RFC Compliance:** Handles multi-value headers as separate flags (`-H "A: 1" -H "A: 2"`) and strictly prioritizes `r.Host` (RFC 7230).
-* **Safety:** Automatically removes `Content-Length` to prevent cURL errors and truncates request bodies (1KB default) to avoid OOM.
-* **Privacy & Security:** Supports masking headers (`*****`), specific JSON keys, or the entire body (`[CONTENT MASKED]`). Also supports environment variable substitution (`$VAR`).
-* **Formatting:** Converts Basic Auth to `-u`, Cookies to `-b`, and supports multi-line output with shell-specific escaping.
+* **URL reconstruction:** Rebuilds absolute URLs for server-side requests, prioritizing `X-Forwarded-Proto` (if enabled) and `r.Host`.
+* **Data parsing:**
+    * Parses `application/x-www-form-urlencoded` bodies into individual `-d` flags.
+    * Parses `multipart/form-data` bodies into `-F` flags, replacing file content with placeholders.
+* **Content safety:** Detects and omits binary media types (e.g., images, PDF) and compressed streams (`Content-Encoding: gzip`) to prevent terminal corruption.
+* **Performance:** Utilizes `http.Request.GetBody` when available to read the body without buffering overhead.
+* **RFC compliance:** Handles multi-value headers as separate flags and respects RFC 7230 Host prioritization.
+* **Redaction:** Supports masking of headers, specific JSON keys, or the entire request body.
+* **Shell compatibility:** Generates syntax for Bash, PowerShell, and Windows CMD.
 
 ## Examples
 
-### 1. Basic POST with Auth & Cookies
+### 1. Basic POST with auth & cookies
 
 ```go
 req, _ := http.NewRequest("POST", "https://api.example.com/test", strings.NewReader(`{"hello":"world"}`))
@@ -91,7 +98,7 @@ cmd, _ := curling.NewFromRequest(req)
 // curl -u 'user:pass' -b 'session=abc' --data-raw '{"hello":"world"}' 'https://api.example.com/test'
 ```
 
-### 2. Multi-line Output for Logging
+### 2. Multi-line output for logging
 
 Generate readable commands for log files using `WithMultiLine()`.
 
@@ -103,7 +110,7 @@ cmd, _ := curling.NewFromRequest(req, curling.WithMultiLine())
 cmd, _ := curling.NewFromRequest(req, curling.WithMultiLine(), curling.WithTargetShell(curling.PowerShell))
 ```
 
-### 3. Masking JSON Keys
+### 3. Masking JSON keys
 
 Granularly redact sensitive fields inside a JSON body while keeping the structure for debugging.
 
@@ -115,7 +122,7 @@ cmd, _ := curling.NewFromRequest(req, curling.WithMaskedJSONFields("password"))
 // curl ... --data-raw '{"user":"admin","password":"*****"}'
 ```
 
-### 4. Env Vars Substitution
+### 4. Env vars substitution
 
 Generate shareable commands using shell variables instead of hardcoded secrets.
 
@@ -127,7 +134,7 @@ cmd, _ := curling.NewFromRequest(req, curling.WithEnvVar("Authorization", "$API_
 // curl ... -H 'Authorization: $API_TOKEN'
 ```
 
-### 5. Middleware: Server-side URL Reconstruction
+### 5. Middleware: Server-side URL reconstruction
 
 When used in middleware, `http.Request` often lacks Scheme and Host. `curling` reconstructs the URL using the following logic:
 
@@ -137,31 +144,63 @@ When used in middleware, `http.Request` often lacks Scheme and Host. `curling` r
     * Otherwise, detects `https` via `r.TLS`.
 * **Host**: Prioritizes `r.Host`, falling back to `r.URL.Host`.
 
+### 6. Form data parsing
+
+Parses `application/x-www-form-urlencoded` into `-d` flags.
+
+```go
+// req is a POST with Content-Type: application/x-www-form-urlencoded
+// Body: "q=golang&sort=desc"
+cmd, _ := curling.NewFromRequest(req)
+
+// Output:
+// curl -d 'q=golang' -d 'sort=desc' 'https://api.example.com/search'
+```
+
+### 7. Multipart uploads
+
+Converts `multipart/form-data` payloads into `-F` flags. File content is omitted with a placeholder.
+
+```go
+// req is a multipart request containing:
+// - Text field "username": "alice"
+// - File field "avatar": filename "avatar.jpg"
+cmd, _ := curling.NewFromRequest(req)
+
+// Output:
+// curl -F 'avatar=@avatar.jpg (OMITTED)' -F 'username=alice' 'https://api.example.com/upload'
+```
+
+### 8. Binary and compressed content
+
+Safe logging for binary streams (image/*, application/pdf) or compressed bodies (gzip).
+
+```go
+// Scenario A: req has header "Content-Encoding: gzip"
+cmd, _ := curling.NewFromRequest(req)
+// Output: curl ... --data-raw '[ENCODED DATA OMITTED: Content-Encoding: gzip]' ...
+
+// Scenario B: req has header "Content-Type: image/jpeg"
+cmd, _ := curling.NewFromRequest(req)
+// Output: curl ... --data-raw '[BINARY DATA OMITTED: image/jpeg]' ...
+```
+
 ## Options
 
-### General Configuration
+### General configuration
 
-| Option                            | Description                                                    |
-|-----------------------------------|----------------------------------------------------------------|
-| `WithLongForm()`                  | Use long-form cURL options (e.g., `--request` instead of `-X`) |
-| `WithSilent()`                    | Set the flag `-s`, `--silent`                                  |
-| `WithCompression()`               | Set the flag `--compressed`                                    |
-| `WithFollowRedirects()`           | Set the flag `-L`, `--location`                                |
-| `WithInsecure()`                  | Set the flag `-k`, `--insecure`                                |
-| `WithRequestTimeout(seconds int)` | Set the flag `-m`, `--max-time`                                |
-| `WithMaxBodySize(bytes int)`      | Override the default 1KB body read limit                       |
-| `WithTrustProxy()`                | Trust `X-Forwarded-Proto` for URL scheme reconstruction        |
+| Option                            | Description                                                                        |
+|-----------------------------------|------------------------------------------------------------------------------------|
+| `WithLongForm()`                  | Use long-form cURL options (e.g., `--request` instead of `-X`)                     |
+| `WithSilent()`                    | Set the flag `-s`, `--silent`                                                      |
+| `WithCompression()`               | Set the flag `--compressed`                                                        |
+| `WithFollowRedirects()`           | Set the flag `-L`, `--location`                                                    |
+| `WithInsecure()`                  | Set the flag `-k`, `--insecure`                                                    |
+| `WithRequestTimeout(seconds int)` | Set the flag `-m`, `--max-time`                                                    |
+| `WithMaxBodySize(bytes int)`      | Override the default 1KB limit. Truncation disables form parsing and JSON masking. |
+| `WithTrustProxy()`                | Trust `X-Forwarded-Proto` for URL scheme reconstruction                            |
 
-### Shell & Formatting
-
-| Option                      | Description                                      |
-|-----------------------------|--------------------------------------------------|
-| `WithMultiLine()`           | Use multi-line output (Unix/Bash style `\`)      |
-| `WithWindowsMultiLine()`    | Use multi-line output (Windows CMD style `^`)    |
-| `WithPowerShellMultiLine()` | Use multi-line output (PowerShell style `` ` ``) |
-| `WithDoubleQuotes()`        | Use double quotes for escaping (Bash only)       |
-
-### Shell & Formatting
+### Shell & formatting
 
 | Option                   | Description                                                                                                    |
 |--------------------------|----------------------------------------------------------------------------------------------------------------|
@@ -169,7 +208,7 @@ When used in middleware, `http.Request` often lacks Scheme and Host. `curling` r
 | `WithTargetShell(shell)` | Set target shell syntax (`POSIX`, `PowerShell`, `WindowsCMD`). Configures escaping and line continuation char. |
 | `WithDoubleQuotes()`     | Use double quotes for escaping (Bash only). Ignored for Windows/PowerShell.                                    |
 
-#### Shell Compatibility Matrix
+#### Shell compatibility matrix
 
 | Shell           | Escaping Strategy                   | Notes                                              |
 |-----------------|-------------------------------------|----------------------------------------------------|
@@ -177,7 +216,7 @@ When used in middleware, `http.Request` often lacks Scheme and Host. `curling` r
 | **PowerShell**  | Backticks (`` ` ``)                 | Enforces double quotes for safety.                 |
 | **Windows CMD** | MS C Runtime rules                  | Enforces double quotes; robust backslash handling. |
 
-### Privacy & Security
+### Privacy & security
 
 | Option                          | Description                                                                                                 | Precedence                       |
 |---------------------------------|-------------------------------------------------------------------------------------------------------------|----------------------------------|

--- a/command.go
+++ b/command.go
@@ -7,10 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 )
@@ -120,8 +121,8 @@ func (d *requestData) extractCookies(r *http.Request) {
 	d.hasCookies = true
 
 	// Sort cookies by name for deterministic output.
-	sort.Slice(cookies, func(i, j int) bool {
-		return cookies[i].Name < cookies[j].Name
+	slices.SortFunc(cookies, func(a, b *http.Cookie) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	var cookieParts []string
@@ -281,7 +282,7 @@ func (c *Command) compile() {
 	commandParts = buildOptions(commandParts, c.cfg, c.data)
 	commandParts = buildAuth(commandParts, c.cfg, c.data, handledHeaders)
 	commandParts = buildCookies(commandParts, c.cfg, c.data, handledHeaders)
-	commandParts = buildData(commandParts, c.cfg, c.data)
+	commandParts = buildData(commandParts, c.cfg, c.data, handledHeaders)
 	commandParts = buildMethod(commandParts, c.cfg, c.data)
 	commandParts = buildURL(commandParts, c.cfg, c.data)
 
@@ -385,43 +386,54 @@ func buildCookies(args []string, cfg config, data requestData, handledHeaders ma
 }
 
 // buildData adds the --data-raw flag if data exists.
-func buildData(args []string, cfg config, data requestData) []string {
+func buildData(args []string, cfg config, data requestData, handledHeaders map[string]bool) []string {
 	// We only add the flag if a body was present (even if empty).
 	if !data.hasData {
 		return args
 	}
 
-	appendData := func(value string) []string {
-		return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, value)))
-	}
-
 	if cfg.maskBody {
-		return appendData("[CONTENT MASKED]")
+		return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, "[CONTENT MASKED]")))
 	}
 
 	contentEncoding := data.request.Header.Get("Content-Encoding")
-	if contentEncoding != "" && contentEncoding != "identity" {
-		return appendData(fmt.Sprintf("[ENCODED DATA OMITTED: Content-Encoding: %s]", contentEncoding))
+	if contentEncoding != "" && !strings.EqualFold(contentEncoding, "identity") {
+		msg := fmt.Sprintf("[ENCODED DATA OMITTED: Content-Encoding: %s]", contentEncoding)
+		return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, msg)))
 	}
 
 	contentType := data.request.Header.Get("Content-Type")
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+
+	// If it is form-urlencoded, parse the content and convert it to multiple -d flags.
+	if mediaType == "application/x-www-form-urlencoded" {
+		return buildFormURLEncoded(args, cfg, data, handledHeaders)
+	}
+
+	// If it is multipart/form-data, parse the content and convert it to multiple -F flags.
+	if mediaType == "multipart/form-data" {
+		return buildMultipartFormData(args, cfg, data, handledHeaders)
+	}
+
 	if isBinaryType(contentType) {
-		return appendData(fmt.Sprintf("[BINARY DATA OMITTED: %s]", contentType))
+		msg := fmt.Sprintf("[BINARY DATA OMITTED: %s]", contentType)
+		return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, msg)))
 	}
 
 	body := data.body.String()
 
+	// JSON masking
 	if len(cfg.maskedJSONFields) > 0 {
 		if data.bodyTruncated {
-			return appendData("[CONTENT MASKED: invalid or truncated JSON]")
+			return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, "[CONTENT MASKED: invalid or truncated JSON]")))
 		}
 
 		maskedBody, err := maskJSONContent(body, cfg.maskedJSONFields)
 		if err != nil {
-			return appendData("[CONTENT MASKED: invalid or truncated JSON]")
+			return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, "[CONTENT MASKED: invalid or truncated JSON]")))
 		}
 
-		return appendData(maskedBody)
+		return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, maskedBody)))
 	}
 
 	// Add the marker if the body was truncated
@@ -433,7 +445,7 @@ func buildData(args []string, cfg config, data requestData) []string {
 		}
 	}
 
-	return appendData(body)
+	return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, body)))
 }
 
 // buildMethod adds the -X flag if it is not a cURL default.
@@ -548,6 +560,120 @@ func sanitizeHeaderValue(cfg config, key, value string) string {
 	}
 
 	return value
+}
+
+// buildFormURLEncoded parses application/x-www-form-urlencoded content and converts it into multiple -d / --data flags
+func buildFormURLEncoded(args []string, cfg config, data requestData, handledHeaders map[string]bool) []string {
+	// Mark Content-Type as handled because cURL will generate it automatically with -d.
+	handledHeaders["Content-Type"] = true
+
+	// If the body was truncated, we cannot safely parse the form data.
+	// We mask the content to avoid printing corrupted form data.
+	if data.bodyTruncated {
+		return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, "[FORM DATA OMITTED: body truncated]")))
+	}
+
+	body := data.body.String()
+
+	values, err := url.ParseQuery(body)
+	if err != nil {
+		return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, "[FORM DATA ERROR: Invalid query format]")))
+	}
+
+	dataParts := make([]string, 0, len(values)*2)
+
+	// Keys are needed to ensure deterministic output order.
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		vals := values[key]
+		// Handle multiple values for the same key (e.g., checkbox lists)
+		for _, val := range vals {
+			// -d / --data is the flag for form content
+			flag := optionForm(cfg.style, "-d", "--data")
+
+			// The key=value pair must be sent as a single string argument.
+			formPart := fmt.Sprintf("%s=%s", key, val)
+
+			// Escape only the combined string argument.
+			dataParts = append(dataParts, flag, escape(cfg.style, formPart))
+		}
+	}
+
+	// Append all generated -d flags to the command
+	return append(args, dataParts...)
+}
+
+// buildMultipartFormData parses multipart/form-data content and converts it into multiple -F / --form flags
+func buildMultipartFormData(args []string, cfg config, data requestData, handledHeaders map[string]bool) []string {
+	// Mark Content-Type as handled because cURL will generate it automatically with -F.
+	handledHeaders["Content-Type"] = true
+
+	// If the body is truncated, parsing is impossible/unreliable.
+	if data.bodyTruncated {
+		formattedValue := fmt.Sprintf("--data-raw %s", escape(cfg.style, "[MULTIPART OMITTED: body truncated]"))
+		return append(args, formattedValue)
+	}
+
+	contentTypeHeader := data.request.Header.Get("Content-Type")
+
+	// Extract boundary from the Content-Type header
+	_, params, err := mime.ParseMediaType(contentTypeHeader)
+	if err != nil {
+		formattedValue := fmt.Sprintf("--data-raw %s", escape(cfg.style, "[MULTIPART ERROR: invalid Content-Type]"))
+		return append(args, formattedValue)
+	}
+
+	boundary := params["boundary"]
+	if boundary == "" {
+		formattedValue := fmt.Sprintf("--data-raw %s", escape(cfg.style, "[MULTIPART ERROR: boundary missing]"))
+		return append(args, formattedValue)
+	}
+
+	// Use the full body buffer to create a multipart reader
+	reader := multipart.NewReader(data.body, boundary)
+	var formValues []string
+	for {
+		part, err := reader.NextPart()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, "[MULTIPART ERROR: parsing failed]")))
+		}
+
+		partData, err := io.ReadAll(part)
+		if err != nil {
+			return append(args, fmt.Sprintf("--data-raw %s", escape(cfg.style, "[MULTIPART ERROR: failed to read part]")))
+		}
+
+		var formValue string
+		formName := part.FormName()
+
+		if part.FileName() != "" {
+			// File upload (Cannot reproduce path, so we use a placeholder)
+			formValue = fmt.Sprintf("%s=@%s (OMITTED)", formName, part.FileName())
+		} else {
+			// Text field
+			formValue = fmt.Sprintf("%s=%s", formName, string(partData))
+		}
+
+		formValues = append(formValues, formValue)
+	}
+
+	slices.Sort(formValues)
+
+	var formTokens []string
+	for _, formValue := range formValues {
+		formTokens = append(formTokens, optionForm(cfg.style, "-F", "--form"), escape(cfg.style, formValue))
+	}
+
+	return append(args, formTokens...)
 }
 
 // isBinaryType checks for common binary MIME types

--- a/command.go
+++ b/command.go
@@ -15,6 +15,23 @@ import (
 	"strings"
 )
 
+// exactBinaryTypes holds MIME types that are binary by strict definition.
+var exactBinaryTypes = map[string]struct{}{
+	"application/octet-stream": {},
+	"application/pdf":          {},
+	"application/zip":          {},
+	"application/gzip":         {},
+	"application/x-tar":        {},
+	"application/x-bzip2":      {},
+}
+
+// binaryPrefixes holds prefixes for MIME types that are always binary (e.g., image/*).
+var binaryPrefixes = []string{
+	"image/",
+	"audio/",
+	"video/",
+}
+
 type readCloser struct {
 	io.Reader
 	io.Closer
@@ -82,64 +99,78 @@ func NewFromRequest(r *http.Request, opts ...Option) (*Command, error) {
 }
 
 // load extracts relevant data from the *http.Request and populates the internal model.
-// It performs a non-destructive read (peek) of the body and restores it,
-// ensuring the request remains valid for subsequent handlers.
 func (d *requestData) load(r *http.Request, cfg config) error {
 	d.request = r
 	d.user, d.pass, d.hasAuth = r.BasicAuth()
-	// Store the original content length
 	d.contentLength = r.ContentLength
 
-	// Pre-parse cookies
+	d.extractCookies(r)
+
+	d.reconstructURL(r, cfg)
+
+	return d.extractBody(r, cfg)
+}
+
+// extractCookies populates the cookies string ensuring deterministic order.
+func (d *requestData) extractCookies(r *http.Request) {
 	cookies := r.Cookies()
-	if len(cookies) > 0 {
-		d.hasCookies = true
-
-		// Sort cookies by name for deterministic output.
-		sort.Slice(cookies, func(i, j int) bool {
-			return cookies[i].Name < cookies[j].Name
-		})
-
-		var cookieParts []string
-		for _, cookie := range cookies {
-			cookieParts = append(cookieParts, cookie.String())
-		}
-		d.cookies = strings.Join(cookieParts, "; ")
+	if len(cookies) == 0 {
+		return
 	}
+	d.hasCookies = true
 
+	// Sort cookies by name for deterministic output.
+	sort.Slice(cookies, func(i, j int) bool {
+		return cookies[i].Name < cookies[j].Name
+	})
+
+	var cookieParts []string
+	for _, cookie := range cookies {
+		cookieParts = append(cookieParts, cookie.String())
+	}
+	d.cookies = strings.Join(cookieParts, "; ")
+}
+
+// reconstructURL handles logic for server-side requests where Scheme/Host might be missing.
+func (d *requestData) reconstructURL(r *http.Request, cfg config) {
 	// We create a shallow copy of the URL structure.
 	// This allows us to modify the Scheme/Host in our local copy (d.uri)
 	// without mutating the original URL which might be shared.
 	u := *r.URL
 	d.uri = &u
 
-	// In a server (middleware) context, r.URL.Scheme and r.URL.Host are often missing.
-	if d.uri.Scheme == "" || d.uri.Host == "" {
-		d.uri.Scheme = "http"
+	if d.uri.Scheme != "" && d.uri.Host != "" {
+		return
+	}
 
-		// Check Proxy Headers (if trusted)
-		if cfg.flags.trustProxy {
-			if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
-				// Handle multiple hops (e.g. "https, http").
-				// We only care about the client's original protocol (the first one).
-				if comma := strings.Index(proto, ","); comma != -1 {
-					proto = strings.TrimSpace(proto[:comma])
-				}
-				d.uri.Scheme = proto
+	d.uri.Scheme = "http"
+
+	// Check Proxy Headers (if trusted)
+	if cfg.flags.trustProxy {
+		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+			// Handle multiple hops (e.g. "https, http").
+			// We only care about the client's original protocol (the first one).
+			if comma := strings.Index(proto, ","); comma != -1 {
+				proto = strings.TrimSpace(proto[:comma])
 			}
-		}
-
-		// TLS check overrides "http", but usually we respect X-Forwarded-Proto if present
-		if d.uri.Scheme == "http" && r.TLS != nil {
-			d.uri.Scheme = "https"
-		}
-
-		// If URL.Host is empty, fallback to the Request.Host (header value).
-		if d.uri.Host == "" && r.Host != "" {
-			d.uri.Host = r.Host
+			d.uri.Scheme = proto
 		}
 	}
 
+	// TLS check overrides "http", but usually we respect X-Forwarded-Proto if present
+	if d.uri.Scheme == "http" && r.TLS != nil {
+		d.uri.Scheme = "https"
+	}
+
+	// If URL.Host is empty, fallback to the Request.Host (header value).
+	if d.uri.Host == "" && r.Host != "" {
+		d.uri.Host = r.Host
+	}
+}
+
+// extractBody handles the complex logic of reading the body without consuming it.
+// It attempts a Fast Path using GetBody first, then falls back to a manual Read & Restore strategy.
+func (d *requestData) extractBody(r *http.Request, cfg config) error {
 	// If there is no Body, we're done.
 	if r.Body == nil || r.Body == http.NoBody {
 		return nil
@@ -151,11 +182,61 @@ func (d *requestData) load(r *http.Request, cfg config) error {
 		return nil
 	}
 
+	// Try to use GetBody if available.
+	// This is preferred for Clients or when GetBody is explicitly set.
+	// It avoids the overhead of bufio.Reader and wrapping the body.
+	if r.GetBody != nil {
+		if err := d.loadUsingGetBody(r, cfg); err == nil {
+			// Success! We are done.
+			return nil
+		}
+		// If GetBody fails (err != nil), we implicitly fall through to the Slow Path.
+	}
+
+	// Fallback to Peek & Restore.
+	// Necessary for Server Middleware where GetBody is usually nil.
+	return d.loadUsingPeek(r, cfg)
+}
+
+// loadUsingGetBody attempts to read the body using the GetBody generator.
+func (d *requestData) loadUsingGetBody(r *http.Request, cfg config) error {
+	freshBody, err := r.GetBody()
+	if err != nil {
+		return err
+	}
+	defer func(freshBody io.ReadCloser) {
+		_ = freshBody.Close()
+	}(freshBody)
+
+	limit := int64(cfg.maxBodySize)
+	// Read one byte beyond the limit to detect truncation.
+	reader := io.LimitReader(freshBody, limit+1)
+
+	buf, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("error reading request body via GetBody: %w", err)
+	}
+
+	d.body = bytes.NewBuffer(buf)
+	d.hasData = true
+
+	// If we read more than 'limit' bytes, the body was truncated.
+	if int64(d.body.Len()) > limit {
+		d.bodyTruncated = true
+		d.body.Truncate(int(limit))
+	}
+
+	return nil
+}
+
+// loadUsingPeek reads the body using bufio.Peek and restores it via a wrapper.
+func (d *requestData) loadUsingPeek(r *http.Request, cfg config) error {
 	// Create the buffer that will hold the body
 	peekSize := cfg.maxBodySize
 
 	// Wrap the original body in a bufio.Reader.
-	// This is essential for non-destructive peeking.
+	// This allows us to peek into the stream without advancing the reader,
+	// effectively buffering the initial bytes.
 	b := bufio.NewReaderSize(r.Body, peekSize+1)
 
 	// Peek(peekSize + 1) is the key to detecting truncation.
@@ -318,6 +399,16 @@ func buildData(args []string, cfg config, data requestData) []string {
 		return appendData("[CONTENT MASKED]")
 	}
 
+	contentEncoding := data.request.Header.Get("Content-Encoding")
+	if contentEncoding != "" && contentEncoding != "identity" {
+		return appendData(fmt.Sprintf("[ENCODED DATA OMITTED: Content-Encoding: %s]", contentEncoding))
+	}
+
+	contentType := data.request.Header.Get("Content-Type")
+	if isBinaryType(contentType) {
+		return appendData(fmt.Sprintf("[BINARY DATA OMITTED: %s]", contentType))
+	}
+
 	body := data.body.String()
 
 	if len(cfg.maskedJSONFields) > 0 {
@@ -457,6 +548,25 @@ func sanitizeHeaderValue(cfg config, key, value string) string {
 	}
 
 	return value
+}
+
+// isBinaryType checks for common binary MIME types
+func isBinaryType(contentType string) bool {
+	ct := strings.ToLower(contentType)
+
+	// Check for the exact match
+	if _, ok := exactBinaryTypes[ct]; ok {
+		return true
+	}
+
+	// Check for prefix match (e.g., image/*)
+	for _, prefix := range binaryPrefixes {
+		if strings.HasPrefix(ct, prefix) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // isMasked checks if the given header key is in the maskedHeaders map.

--- a/command_body_test.go
+++ b/command_body_test.go
@@ -2,6 +2,7 @@ package curling
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,6 +13,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type errReader struct{}
+
+func (e *errReader) Read(_ []byte) (n int, err error) {
+	return 0, assert.AnError
+}
 
 func Test_NewFromRequest_body(t *testing.T) {
 	t.Parallel()
@@ -380,6 +387,71 @@ func Test_NewFromRequest_body(t *testing.T) {
 			want:    "curl --data-raw '[CONTENT MASKED: invalid or truncated JSON]' 'https://localhost/test'",
 			wantErr: assert.NoError,
 		},
+		{
+			name: "body with image/jpeg content type is omitted",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("binary-jpeg-data")),
+					Header: http.Header{"Content-Type": {"image/jpeg"}},
+				},
+			},
+			want:    "curl --data-raw '[BINARY DATA OMITTED: image/jpeg]' 'https://localhost/test' -H 'Content-Type: image/jpeg'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "body with application/octet-stream content type is omitted",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("raw-binary-stream")),
+					Header: http.Header{"Content-Type": {"application/octet-stream"}},
+				},
+			},
+			want:    "curl --data-raw '[BINARY DATA OMITTED: application/octet-stream]' 'https://localhost/test' -H 'Content-Type: application/octet-stream'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "body with application/zip content type is omitted",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("zip-archive")),
+					Header: http.Header{"Content-Type": {"application/zip"}},
+				},
+			},
+			want:    "curl --data-raw '[BINARY DATA OMITTED: application/zip]' 'https://localhost/test' -H 'Content-Type: application/zip'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "body with text/plain content type is not omitted",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("text data")),
+					Header: http.Header{"Content-Type": {"text/plain"}},
+				},
+			},
+			want:    "curl --data-raw 'text data' 'https://localhost/test' -H 'Content-Type: text/plain'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "body with Content-Encoding gzip is omitted, overriding Content-Type",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`{"status": "ok"}`)),
+					Header: http.Header{"Content-Type": {"application/json"}, "Content-Encoding": {"gzip"}},
+				},
+			},
+			want:    "curl --data-raw '[ENCODED DATA OMITTED: Content-Encoding: gzip]' 'https://localhost/test' -H 'Content-Encoding: gzip' -H 'Content-Type: application/json'",
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -394,6 +466,61 @@ func Test_NewFromRequest_body(t *testing.T) {
 			assert.Equal(t, tt.want, got.String())
 		})
 	}
+}
+
+func TestNewFromRequest_GetBody_Success(t *testing.T) {
+	t.Parallel()
+
+	payload := "fast-path-data"
+	req, err := http.NewRequest(http.MethodPost, "https://localhost/test", strings.NewReader(payload))
+	require.NoError(t, err)
+
+	cmd, err := NewFromRequest(req)
+	require.NoError(t, err)
+	assert.Contains(t, cmd.String(), fmt.Sprintf("--data-raw '%s'", payload))
+}
+
+func TestNewFromRequest_GetBody_Truncation(t *testing.T) {
+	t.Parallel()
+	payload := "1234567890"
+	req, err := http.NewRequest(http.MethodPost, "https://localhost/test", strings.NewReader(payload))
+	require.NoError(t, err)
+
+	cmd, err := NewFromRequest(req, WithMaxBodySize(5))
+	require.NoError(t, err)
+	assert.Contains(t, cmd.String(), "--data-raw '12345... (truncated body, total 10 bytes)'")
+}
+
+func TestNewFromRequest_GetBody_Failure_Fallback(t *testing.T) {
+	t.Parallel()
+	payload := "data-via-fallback"
+	req, err := http.NewRequest(http.MethodPost, "https://localhost/test", strings.NewReader(payload))
+	require.NoError(t, err)
+
+	req.GetBody = func() (io.ReadCloser, error) {
+		return nil, assert.AnError
+	}
+
+	cmd, err := NewFromRequest(req)
+	require.NoError(t, err)
+	assert.Contains(t, cmd.String(), fmt.Sprintf("--data-raw '%s'", payload))
+
+	restored, _ := io.ReadAll(req.Body)
+	assert.Equal(t, payload, string(restored))
+}
+
+func TestNewFromRequest_GetBody_ReadError(t *testing.T) {
+	t.Parallel()
+	req, err := http.NewRequest(http.MethodPost, "https://localhost/test", strings.NewReader("ok"))
+	require.NoError(t, err)
+
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(&errReader{}), nil
+	}
+
+	cmd, err := NewFromRequest(req)
+	require.Nil(t, err)
+	assert.Contains(t, cmd.String(), "--data-raw 'ok'")
 }
 
 func TestNewFromRequest_BodyRestoration(t *testing.T) {

--- a/command_body_test.go
+++ b/command_body_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -14,10 +15,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testMultipartBoundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+
 type errReader struct{}
 
 func (e *errReader) Read(_ []byte) (n int, err error) {
 	return 0, assert.AnError
+}
+
+// createMultipartBody creates a sample body with text and file parts for testing.
+func createMultipartBody(t *testing.T, textValue, fileName string) *bytes.Buffer {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	err := writer.SetBoundary(testMultipartBoundary)
+	require.NoError(t, err)
+
+	// Text Field part
+	w, err := writer.CreateFormField("username")
+	require.NoError(t, err)
+	_, _ = w.Write([]byte(textValue))
+
+	// File Field part
+	w, err = writer.CreateFormFile("avatar", fileName)
+	require.NoError(t, err)
+	_, _ = w.Write([]byte("file-content-mock"))
+
+	require.NoError(t, writer.Close())
+	return &body
 }
 
 func Test_NewFromRequest_body(t *testing.T) {
@@ -90,6 +114,56 @@ func Test_NewFromRequest_body(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "method: DELETE generates -X flag",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodDelete,
+					URL:    testUrl,
+					Body:   http.NoBody,
+				},
+			},
+			want:    "curl -X 'DELETE' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "method: PATCH with body generates -X flag",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPatch,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`{"op":"replace"}`)),
+				},
+			},
+			want:    "curl --data-raw '{\"op\":\"replace\"}' -X 'PATCH' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "binary: prefix match for video/webm",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("video-data")),
+					Header: http.Header{"Content-Type": {"video/webm"}},
+				},
+			},
+			want:    "curl --data-raw '[BINARY DATA OMITTED: video/webm]' 'https://localhost/test' -H 'Content-Type: video/webm'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "binary: exact match for application/x-tar",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("tar-data")),
+					Header: http.Header{"Content-Type": {"application/x-tar"}},
+				},
+			},
+			want:    "curl --data-raw '[BINARY DATA OMITTED: application/x-tar]' 'https://localhost/test' -H 'Content-Type: application/x-tar'",
+			wantErr: assert.NoError,
+		},
+		{
 			name: "masked body option",
 			args: args{
 				r: &http.Request{
@@ -100,6 +174,19 @@ func Test_NewFromRequest_body(t *testing.T) {
 				opts: []Option{WithMaskedBody()},
 			},
 			want:    "curl --data-raw '[CONTENT MASKED]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "json: invalid syntax triggers fallback masking",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader(`{"key": "val"`)),
+				},
+				opts: []Option{WithMaskedJSONFields("key")},
+			},
+			want:    "curl --data-raw '[CONTENT MASKED: invalid or truncated JSON]' 'https://localhost/test'",
 			wantErr: assert.NoError,
 		},
 		{
@@ -452,6 +539,59 @@ func Test_NewFromRequest_body(t *testing.T) {
 			want:    "curl --data-raw '[ENCODED DATA OMITTED: Content-Encoding: gzip]' 'https://localhost/test' -H 'Content-Encoding: gzip' -H 'Content-Type: application/json'",
 			wantErr: assert.NoError,
 		},
+		{
+			name: "form: basic urlencoded data conversion to -d",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("user=alice&id=101")),
+					Header: http.Header{"Content-Type": {"application/x-www-form-urlencoded"}},
+				},
+			},
+			want:    "curl -d 'id=101' -d 'user=alice' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "form: multiple values for a single key",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("role=admin&role=guest")),
+					Header: http.Header{"Content-Type": {"application/x-www-form-urlencoded"}},
+				},
+			},
+			want:    "curl -d 'role=admin' -d 'role=guest' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "form: truncated body forces masked form message",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("key=value")),
+					Header: http.Header{"Content-Type": {"application/x-www-form-urlencoded"}},
+				},
+				opts: []Option{WithMaxBodySize(3)},
+			},
+			want:    "curl --data-raw '[FORM DATA OMITTED: body truncated]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "form: invalid format parsing fails secure",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("a=1&b%")),
+					Header: http.Header{"Content-Type": {"application/x-www-form-urlencoded"}},
+				},
+			},
+			want:    "curl --data-raw '[FORM DATA ERROR: Invalid query format]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -598,4 +738,199 @@ func TestNewFromRequest_BodyRestoration_Masked(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, originalData, restoredBody)
+}
+
+func TestNewFromRequest_MultipartBody(t *testing.T) {
+	t.Parallel()
+
+	testUrl := &url.URL{
+		Scheme: "https",
+		Host:   "localhost",
+		Path:   "test",
+	}
+
+	type args struct {
+		r    *http.Request
+		opts []Option
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "multipart: success with text and file placeholder",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(createMultipartBody(t, "Alice", "photo.jpg")),
+					Header: http.Header{"Content-Type": {"multipart/form-data; boundary=" + testMultipartBoundary}},
+				},
+			},
+			want:    "curl -F 'avatar=@photo.jpg (OMITTED)' -F 'username=Alice' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "multipart: body truncated (fail-secure)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(createMultipartBody(t, "Alice", "photo.jpg")),
+					Header: http.Header{"Content-Type": {"multipart/form-data; boundary=" + testMultipartBoundary}},
+				},
+				opts: []Option{WithMaxBodySize(10)},
+			},
+			want:    "curl --data-raw '[MULTIPART OMITTED: body truncated]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "multipart: boundary missing in header (parsing error)",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(createMultipartBody(t, "Bob", "doc.pdf")),
+					Header: http.Header{"Content-Type": {"multipart/form-data"}},
+				},
+			},
+			want:    "curl --data-raw '[MULTIPART ERROR: boundary missing]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "multipart: incomplete final boundary causes read part error",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("--" + testMultipartBoundary + "\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nvalue")),
+					Header: http.Header{"Content-Type": {"multipart/form-data; boundary=" + testMultipartBoundary}},
+				},
+			},
+			want:    "curl --data-raw '[MULTIPART ERROR: failed to read part]' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "multipart: missing part header parses with empty key",
+			args: args{
+				r: &http.Request{
+					Method: http.MethodPost,
+					URL:    testUrl,
+					Body:   io.NopCloser(strings.NewReader("--" + testMultipartBoundary + "\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nvalue\r\n--" + testMultipartBoundary + "\r\n\r\nvalue2\r\n--" + testMultipartBoundary + "--")),
+					Header: http.Header{"Content-Type": {"multipart/form-data; boundary=" + testMultipartBoundary}},
+				},
+			},
+			want:    "curl -F '=value2' -F 'a=value' 'https://localhost/test'",
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd, err := NewFromRequest(tt.args.r, tt.args.opts...)
+
+			if !tt.wantErr(t, err, "NewFromRequest() error") {
+				return
+			}
+
+			assert.Equal(t, tt.want, cmd.String())
+		})
+	}
+}
+
+func TestBuildMultipartFormData_Internal_Errors(t *testing.T) {
+	t.Parallel()
+
+	boundary := "testboundary"
+	validContentType := "multipart/form-data; boundary=" + boundary
+
+	cfg := config{
+		style: outputStyle{
+			shell:            POSIX,
+			lineContinuation: "\\",
+		},
+	}
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "force NextPart error (parsing failed)",
+			body: "--" + boundary + "\r\nInvalid-Header-Format-No-Colon\r\n\r\nData",
+			want: "curl --data-raw '[MULTIPART ERROR: parsing failed]'",
+		},
+		{
+			name: "force ReadAll error (failed to read part)",
+			body: "--" + boundary + "\r\nContent-Disposition: form-data; name=\"field\"\r\n\r\nTruncatedValue",
+			want: "curl --data-raw '[MULTIPART ERROR: failed to read part]'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("POST", "http://localhost", nil)
+			req.Header.Set("Content-Type", validContentType)
+
+			data := requestData{
+				request: req,
+				body:    bytes.NewBufferString(tt.body),
+				hasData: true,
+			}
+
+			handledHeaders := make(map[string]bool)
+
+			gotSlice := buildMultipartFormData([]string{"curl"}, cfg, data, handledHeaders)
+			got := strings.Join(gotSlice, " ")
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildMultipartFormData_Initialization_Errors(t *testing.T) {
+	t.Parallel()
+
+	cfg := config{
+		style: outputStyle{shell: POSIX},
+	}
+
+	tests := []struct {
+		name        string
+		contentType string
+		want        string
+	}{
+		{
+			name:        "invalid content type structure",
+			contentType: "multipart/form-data boundary=wrong",
+			want:        "curl --data-raw '[MULTIPART ERROR: invalid Content-Type]'",
+		},
+		{
+			name:        "missing boundary parameter",
+			contentType: "multipart/form-data",
+			want:        "curl --data-raw '[MULTIPART ERROR: boundary missing]'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("POST", "http://localhost", nil)
+			req.Header.Set("Content-Type", tt.contentType)
+
+			data := requestData{
+				request: req,
+				body:    bytes.NewBufferString(""),
+				hasData: true,
+			}
+
+			gotSlice := buildMultipartFormData([]string{"curl"}, cfg, data, make(map[string]bool))
+			got := strings.Join(gotSlice, " ")
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
## Changes

* **Form Data:** Implemented logic to parse `application/x-www-form-urlencoded` into deterministic `-d` flags.
* **Multipart:** Implemented logic to parse `multipart/form-data` into `-F` flags. File parts are replaced with placeholders (`@filename (OMITTED)`).
* **Safety:** Added checks to omit request bodies with binary MIME types (e.g., images, archives) or compression (`Content-Encoding`).
* **Performance:** Implemented a non-destructive fast path using `http.Request.GetBody` when available, bypassing `bufio.Peek` buffering.
* **Refactoring:** Split `load` function into dedicated strategies (`loadUsingGetBody`, `loadUsingPeek`) and consolidated `buildData` routing using `mime.ParseMediaType`.
* **Documentation:** Updated README.md with new features, examples, and shell compatibility matrix.
* **Testing:** Added unit tests for form parsing, binary detection, and coverage gaps.